### PR TITLE
ci: 引入固件编译检查与自动 Release 工作流

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/binarykeyboard-builder
 
 jobs:
   build-and-push:
@@ -24,6 +23,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set lowercase image name
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository_owner }}/binarykeyboard-builder' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build CH592F (release)
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/binarykeyboard-builder:latest
+      image: ghcr.io/meowkj/binarykeyboard-builder:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     container:
-      image: ghcr.io/${{ github.repository_owner }}/binarykeyboard-builder:latest
+      image: ghcr.io/meowkj/binarykeyboard-builder:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- 新增 `firmware-build.yml`：PR/push 触发固件编译检查
- 新增 `release.yml`：合并到 main 后自动构建并发布 Release（含工具链版本信息）
- 新增 `build-docker-image.yml`：构建并推送编译环境 Docker 镜像至 GHCR
- 新增 `docker/builder/Dockerfile`：基于 Ubuntu 22.04，内置 WCH riscv-wch-elf-gcc 工具链

## 首次合并说明

镜像首次构建需要时间，`build-docker-image` 会在本次合并后自动触发。
`release.yml` 可能因镜像尚未就绪而失败，属正常现象，镜像构建完成后即可正常使用。