### PR TITLE
fix(ci): 修复容器内 git safe.directory 报错

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         run: cmake --build --preset release
         working-directory: firmware/CH592F
 
+      - name: Fix git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Generate version tag
         id: version
         run: |


### PR DESCRIPTION
Docker 容器内 git 检测到目录所有权问题，添加 safe.directory 配置修复。