### PR TITLE
为发布流程补充 CH552G / CH592F 固件尺寸报告

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,15 @@ jobs:
             ${{ steps.artifacts.outputs.hex }}
           retention-days: 7
 
+      - name: Emit size report
+        run: python3 tools/scripts/ch592f.py size-json --keyboard ${{ matrix.keyboard }} --profile release --out size-ch592f-${{ matrix.keyboard }}.json
+
+      - name: Upload size report
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-ch592f-${{ matrix.keyboard }}
+          path: size-ch592f-${{ matrix.keyboard }}.json
+
   build-ch552g:
     name: Package CH552G (${{ matrix.keyboard }})
     runs-on: ubuntu-latest
@@ -110,6 +119,15 @@ jobs:
             ${{ steps.artifacts.outputs.bin }}
             ${{ steps.artifacts.outputs.hex }}
           retention-days: 7
+
+      - name: Emit size report
+        run: python3 tools/scripts/ch552g.py size-json --keyboard ${{ matrix.keyboard }} --out size-ch552g-${{ matrix.keyboard }}.json
+
+      - name: Upload size report
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-ch552g-${{ matrix.keyboard }}
+          path: size-ch552g-${{ matrix.keyboard }}.json
 
   build-studio:
     name: Build Studio
@@ -164,6 +182,13 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Download size reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: size-*
+          path: sizes
+          merge-multiple: true
+
       - name: Generate version tag
         id: version
         run: |
@@ -211,6 +236,9 @@ jobs:
               echo "| \`${fname}\` | ${fsize} | ${desc} |"
             done
             echo
+            if ls sizes/*.json >/dev/null 2>&1; then
+              python3 tools/scripts/render_size_table.py sizes/*.json
+            fi
             echo "### 🔧 构建环境"
             echo
             echo "| 属性 | 值 |"

--- a/tools/scripts/ch552g.py
+++ b/tools/scripts/ch552g.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import ctypes
 import filecmp
+import json
 import os
 import platform
 import re
@@ -491,6 +492,29 @@ def show_artifact(keyboard: str, artifact_type: str) -> int:
     return 0 if path.is_file() else 1
 
 
+def emit_size_json(keyboard: str, out: Path) -> int:
+    """Write build size metrics to a JSON file for CI consumption."""
+    build_dir = build_dir_for(keyboard)
+    mem_rows, _ = _parse_mem_report(build_dir / "CH552G.ihx.mem")
+
+    if not mem_rows:
+        warn(f"No memory report found for {keyboard}")
+        return 1
+
+    result: dict = {"chip": "CH552G", "keyboard": keyboard, "regions": {}}
+    for row in mem_rows:
+        result["regions"][row.name] = {"used": row.used, "total": row.total}
+
+    bin_file = raw_artifact_paths(build_dir)["bin"]
+    if bin_file.is_file():
+        result["bin_size"] = bin_file.stat().st_size
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2))
+    ok(f"Size JSON → {out}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tools/scripts/ch552g.py",
@@ -513,6 +537,11 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("all", "ihx", "hex", "bin"),
         help="Artifact type to print",
     )
+
+    p_size = sub.add_parser("size-json", help="Emit build size report as JSON")
+    p_size.add_argument("-k", "--keyboard", default=DEFAULT_KEYBOARD, help="BASIC / KNOB / 5KEY")
+    p_size.add_argument("-v", "--variant", dest="keyboard_legacy", help=argparse.SUPPRESS)
+    p_size.add_argument("-o", "--out", required=True, type=Path, help="Output JSON path")
 
     return parser
 
@@ -538,6 +567,8 @@ def main() -> int:
         if args.command == "clean":
             clean(keyboard)
             return 0
+        if args.command == "size-json":
+            return emit_size_json(keyboard, args.out)
         if args.command == "artifact":
             return show_artifact(keyboard, args.type)
         parser.error(f"Unsupported command: {args.command}")

--- a/tools/scripts/ch592f.py
+++ b/tools/scripts/ch592f.py
@@ -533,6 +533,39 @@ def show_artifact(keyboard: str, profile: str, artifact_type: str) -> int:
     return 0 if path.is_file() else 1
 
 
+def emit_size_json(keyboard: str, profile: str, out: Path) -> int:
+    """Write build size metrics to a JSON file for CI consumption."""
+    preset = preset_for(keyboard, profile)
+    build_dir = build_dir_for(preset)
+    mem = _read_memory_lengths_from_linker(LINKER_SCRIPT)
+    usage = _artifact_region_usage_from_objdump(build_dir)
+    if not usage:
+        size_row = _size_row_from_artifact(build_dir)
+        if size_row:
+            text, data, bss = size_row
+            usage = {"FLASH": text + data, "RAM": data + bss}
+
+    if not usage:
+        warn(f"Cannot determine size for {keyboard} ({profile})")
+        return 1
+
+    result: dict = {"chip": "CH592F", "keyboard": keyboard, "regions": {}}
+    for region in ("FLASH", "RAM"):
+        used = usage.get(region)
+        total = mem.get(region)
+        if used is not None and total:
+            result["regions"][region] = {"used": used, "total": total}
+
+    bin_file = raw_artifact_paths(build_dir)["bin"]
+    if bin_file.is_file():
+        result["bin_size"] = bin_file.stat().st_size
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2))
+    ok(f"Size JSON → {out}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tools/scripts/ch592f.py",
@@ -557,6 +590,11 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("all", "elf", "bin", "hex", "map"),
         help="Artifact type to print",
     )
+
+    p_size = sub.add_parser("size-json", help="Emit build size report as JSON")
+    p_size.add_argument("-k", "--keyboard", default=DEFAULT_KEYBOARD, help="5KEY / KNOB")
+    p_size.add_argument("--profile", default=DEFAULT_PROFILE, help="release / debug")
+    p_size.add_argument("-o", "--out", required=True, type=Path, help="Output JSON path")
 
     return parser
 
@@ -587,6 +625,8 @@ def main() -> int:
         if args.command == "clean":
             clean(keyboard, profile)
             return 0
+        if args.command == "size-json":
+            return emit_size_json(keyboard, profile, args.out)
         if args.command == "artifact":
             return show_artifact(keyboard, profile, args.type)
         parser.error(f"Unsupported command: {args.command}")

--- a/tools/scripts/render_size_table.py
+++ b/tools/scripts/render_size_table.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Render firmware size JSON reports as a markdown table for release notes."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def fmt(region: dict) -> str:
+    if not region:
+        return "-"
+    used = region["used"]
+    total = region["total"]
+    u_kb = used / 1024
+    t_kb = total / 1024
+    pct = used / total * 100 if total else 0
+    return f"{u_kb:.1f} / {t_kb:.1f} KB ({pct:.1f}%)"
+
+
+def main() -> None:
+    files = [Path(f) for f in sys.argv[1:] if Path(f).is_file()]
+    if not files:
+        return
+
+    reports = [json.loads(f.read_text()) for f in files]
+    reports.sort(key=lambda r: (r["chip"], r["keyboard"]))
+
+    print("### 📊 Flash / RAM 占用")
+    print()
+    print("| 固件 | Flash | RAM |")
+    print("|------|-------|-----|")
+    for r in reports:
+        name = f'{r["chip"]}-{r["keyboard"]}'
+        flash = r["regions"].get("FLASH", {})
+        ram = r["regions"].get("RAM", r["regions"].get("XRAM", {}))
+        print(f"| `{name}` | {fmt(flash)} | {fmt(ram)} |")
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更内容

本次改动为固件发布流程补充尺寸报告能力，便于在 Release 中直接查看各固件的 Flash / RAM 占用情况。

### 主要更新

- 为 CH552G 构建脚本新增 `size-json` 子命令
- 为 CH592F 构建脚本新增 `size-json` 子命令
- 新增 `tools/scripts/render_size_table.py`，用于将尺寸 JSON 渲染为 Markdown 表格
- 更新 release workflow，在构建阶段上传尺寸报告，并在发布说明中自动追加尺寸占用表

## 验证情况

已完成本地验证：

- `python3 -m py_compile tools/scripts/ch552g.py tools/scripts/ch592f.py tools/scripts/render_size_table.py`
- `python3 tools/scripts/ch552g.py build --keyboard BASIC`
- `python3 tools/scripts/ch552g.py size-json --keyboard BASIC --out /tmp/ch552-basic-size.json`
- `python3 tools/scripts/ch592f.py build --keyboard 5KEY --profile release`
- `python3 tools/scripts/ch592f.py size-json --keyboard 5KEY --profile release --out /tmp/ch592-5key-size.json`
- `python3 tools/scripts/render_size_table.py /tmp/ch552-basic-size.json /tmp/ch592-5key-size.json`

## 说明

当前功能已可在本地正常生成尺寸报告并渲染 Markdown 表格，后续合并到 `main` 后可继续观察 GitHub Actions 中 release 页面展示效果。
