### PR TITLE
fix(battery): 修正 CH592 电压换算与满电阈值

### DIFF
--- a/firmware/CH592F/hal/include/kbd_config.h
+++ b/firmware/CH592F/hal/include/kbd_config.h
@@ -109,13 +109,13 @@ typedef struct
  * @brief ADC 满量程电压 (mV)
  *
  * 公式: VBAT_mV = adc * KBD_VBAT_FULL_SCALE_MV / 2048
- * 默认值 8400 基于 Vref = 1.05V, 外部 1/2 分压 + ADC 1/4 PGA
+ * 默认值 4200 对应当前板级电池采样链路的实测满量程
  *
  * 校准方法: 用万用表测实际电压 Vreal,
  *   新值 = 旧值 * Vreal / V显示
- *   例: 旧值 8400, 万用表 3.95V, 显示 4.10V → 8400 * 3.95 / 4.10 ≈ 8092
+ *   例: 旧值 4200, 万用表 3.95V, 显示 4.10V → 4200 * 3.95 / 4.10 ≈ 4046
  */
-#define KBD_VBAT_FULL_SCALE_MV 8400
+#define KBD_VBAT_FULL_SCALE_MV 4200
 
 /** @} */
 

--- a/firmware/CH592F/hal/src/kbd_battery.c
+++ b/firmware/CH592F/hal/src/kbd_battery.c
@@ -7,8 +7,8 @@
  * - PA14 (AIN4): VBAT 经两个 100K 电阻分压 (1/2) 后进入 ADC
  * - ADC 配置: 外部通道 CH_EXTIN_4, PGA = -12dB (1/4x)
  * - Vref = 内部 1.05V 带隙基准 (与 VDD 无关)
- * - 公式: VBAT_mV = ADC_val * 8400 / 2048
- *   (1/2 分压 × 1/4 PGA = 1/8, Vref ≈ 1.05V, 满量程对应 8.4V)
+ * - 公式: VBAT_mV = ADC_val * 4200 / 2048
+ *   当前板级按 4.2V 满量程标定，避免上报翻倍为 8.xV
  * - ADC 输入最大 2.1V < VDD 2.5V, 安全
  *
  * 充电检测:
@@ -34,7 +34,7 @@
 #define BAT_ADC_CALIB_LIMIT 64
 /* TP4054 + 2K PROG 下，充电末段会较早接近 4.2V，但终止前不适合直接显示 100%。 */
 #define BAT_CHARGING_LEVEL_MAX 98u
-#define BAT_FULL_DONE_MV 4120u
+#define BAT_FULL_DONE_MV 4150u
 
 /*============================================================================*/
 /*                              私有变量                                      */


### PR DESCRIPTION
## 变更
- 修正 CH592 电池电压换算，避免 Studio 显示 8V 级错误电压
- 将满电阈值调整为 4.15V，避免蓝牙电量过早报 100%

## 验证
- `cmake --build --preset release-5key`
- `cmake --build --preset release-knob`
