### PR TITLE
fix(versioning): 跳过两段式发布版本解析

### DIFF
--- a/tools/scripts/versioning.py
+++ b/tools/scripts/versioning.py
@@ -194,7 +194,10 @@ def _latest_release_versions() -> tuple[str, dict[str, str]] | None:
 def _latest_release_patch_for_base(versions: dict[str, str], major: int, minor: int) -> int | None:
     patches: list[int] = []
     for version in versions.values():
-        rel_major, rel_minor, rel_patch = _split_version(version)
+        try:
+            rel_major, rel_minor, rel_patch = _split_version(version)
+        except ValueError:
+            continue
         if rel_major == major and rel_minor == minor:
             patches.append(rel_patch)
     if not patches:


### PR DESCRIPTION
## 变更
- 修正版本解析逻辑，跳过两段式发布版本，避免 Studio 构建读取 `0.1` 时失败

## 验证
- `pnpm --dir tools/studio run build`
