### PR TITLE
fix(release): 修正 MeowISP 打包命名与版本注入

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -742,6 +742,10 @@ jobs:
       - name: Generate release manifest
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          BK_VERSION_STUDIO: ${{ steps.version.outputs.studio_version }}
+          BK_VERSION_MEOWISP: ${{ steps.version.outputs.meowisp_version }}
+          BK_VERSION_CH592: ${{ steps.version.outputs.ch592_version }}
+          BK_VERSION_CH552: ${{ steps.version.outputs.ch552_version }}
         run: |
           mkdir -p dist/api
           python3 tools/scripts/versioning.py emit-release-manifest \

--- a/tools/meowisp/scripts/package_portable.py
+++ b/tools/meowisp/scripts/package_portable.py
@@ -56,7 +56,7 @@ macOS note:
 
 
 def create_zip(source_dir: Path, archive_base: Path) -> Path:
-    archive_path = archive_base.with_suffix(".zip")
+    archive_path = archive_base.parent / (archive_base.name + ".zip")
     with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for item in sorted(source_dir.rglob("*")):
             zf.write(item, item.relative_to(source_dir.parent))
@@ -64,7 +64,7 @@ def create_zip(source_dir: Path, archive_base: Path) -> Path:
 
 
 def create_targz(source_dir: Path, archive_base: Path) -> Path:
-    archive_path = archive_base.with_suffix(".tar.gz")
+    archive_path = archive_base.parent / (archive_base.name + ".tar.gz")
     with tarfile.open(archive_path, "w:gz") as tf:
         tf.add(source_dir, arcname=source_dir.name)
     return archive_path

--- a/tools/scripts/versioning.py
+++ b/tools/scripts/versioning.py
@@ -244,6 +244,12 @@ def component_version(component: str, build_number: int | None = None) -> str:
     meta = component_meta(component)
     major, minor = _split_base_version(str(meta["base_version"]))
     version_parts = int(meta.get("version_parts", 3))
+
+    # Per-component override (e.g. BK_VERSION_CH592=3.0.34)
+    env_version = os.environ.get(f"BK_VERSION_{component.upper()}")
+    if env_version is not None:
+        return env_version.strip()
+
     if version_parts == 2:
         if _is_local_build():
             return "dev"


### PR DESCRIPTION
## 变更
- 修正 MeowISP 便携包在带版本号时的归档命名
- 为 release manifest 显式注入本次工作流计算出的版本号
- 避免主线发布时因旧资产缺失或版本漂移导致 release 产物不一致

## 验证
- `python tools/meowisp/scripts/package_portable.py --platform linux --arch amd64 --version 0.1 ...`
- `python tools/scripts/versioning.py emit-release-manifest --out ...`
