### PR TITLE
fix(ch592): complete wireless power and flashing fixes

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "studio": {
-      "base_version": "3.0",
+      "base_version": "3.1",
       "paths": [
         "tools/studio"
       ]
@@ -14,7 +14,7 @@
       ]
     },
     "ch592": {
-      "base_version": "3.0",
+      "base_version": "3.1",
       "chip_family": "CH592F",
       "protocol_family": "BKHID64",
       "paths": [

--- a/firmware/CH592F/CMakeLists.txt
+++ b/firmware/CH592F/CMakeLists.txt
@@ -76,7 +76,6 @@ endif()
 #   StdPeriphDriver/CH59x_flash.c CH59x_lcd.c CH59x_timer2.c CH59x_timer3.c
 #   StdPeriphDriver/CH59x_uart0.c CH59x_uart1.c (unused in current build; APIs resolved elsewhere / not enabled)
 #   ble/core/src/KEY.c  LED.c
-#   ble/core/src/ble_sleep.c (HAL_SLEEP = FALSE in current config)
 #   app/Main_Test.c  app/RGB_TEST.c
 #   RVMSIS/core_riscv.c (current firmware only uses header inlines/macros)
 # ---------------------------------------------------------------------------
@@ -99,6 +98,7 @@ set(CH592_BLE_CORE_SOURCES
     # BLE – core
     ble/core/src/ble_mcu.c
     ble/core/src/ble_rtc.c
+    ble/core/src/ble_sleep.c
 )
 
 set(CH592_BLE_HID_SOURCES
@@ -143,14 +143,9 @@ set(CH592_VENDOR_DRIVER_SOURCES
     SDK/StdPeriphDriver/CH59x_sys.c
     SDK/StdPeriphDriver/CH59x_timer0.c
     SDK/StdPeriphDriver/CH59x_timer1.c
+    SDK/StdPeriphDriver/CH59x_uart1.c
     SDK/StdPeriphDriver/CH59x_usbdev.c
 )
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    list(APPEND CH592_VENDOR_DRIVER_SOURCES
-        SDK/StdPeriphDriver/CH59x_uart1.c
-    )
-endif()
 
 set(CH592_STARTUP_SOURCES
     # Startup (assembly)
@@ -200,6 +195,8 @@ set(CH592_COMPILE_DEFINITIONS
     ${KBD_LAYOUT_DEFINE}
     KBD_MODEL_NAME=\"${KBD_MODEL_UPPER}\"
     KBD_DEVICE_NAME=\"${KBD_DEVICE_NAME}\"
+    HAL_SLEEP=FALSE
+    DCDC_ENABLE=TRUE
 )
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -211,8 +208,9 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     )
 else()
     list(APPEND CH592_COMPILE_DEFINITIONS
-        UART_LOG_ENABLE=0
-        KBD_DEBUG_BUILD=0
+        DEBUG=Debug_UART1
+        UART_LOG_ENABLE=1
+        KBD_DEBUG_BUILD=1
         KBD_USB_LOG_ENABLE=0
     )
 endif()

--- a/firmware/CH592F/app/Main.c
+++ b/firmware/CH592F/app/Main.c
@@ -52,15 +52,16 @@ int main(void)
     /* 设置系统时钟 */
     SetSysClock(CLK_SOURCE_PLL_60MHz);
 
-#if (defined(HAL_SLEEP)) && (HAL_SLEEP == TRUE)
-    /* 低功耗模式：配置所有GPIO为上拉输入 */
-    GPIOA_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_PU);
-    GPIOB_ModeCfg(GPIO_Pin_All, GPIO_ModeIN_PU);
+#if (defined(DCDC_ENABLE)) && (DCDC_ENABLE == TRUE)
+    /* 启用内部 DCDC，节省核心功耗（约 30%） */
+    PWR_DCDCCfg(ENABLE);
 #endif
 
 #ifdef DEBUG
     /* 调试串口初始化 */
     Debug_Init();
+    /* 最早期串口探活：用于确认 UART1(PB13 TX) 链路正常 */
+    Log_Output("I", "BOOT", "UART alive");
 #endif
 
     /* BLE 库初始化（提供 TMOS 调度器，USB/BLE 模式都需要） */

--- a/firmware/CH592F/ble/hid/include/ble_hid.h
+++ b/firmware/CH592F/ble/hid/include/ble_hid.h
@@ -71,6 +71,12 @@ int BLE_HID_StartAdvertising(void);
 int BLE_HID_StopAdvertising(void);
 
 /**
+ * @brief 设置断链后是否自动恢复广播
+ * @param enable true=自动恢复广播，false=保持静默
+ */
+void BLE_HID_SetAutoResumeAdvertising(bool enable);
+
+/**
  * @brief 断开连接
  * @return 0 成功，其他失败
  */

--- a/firmware/CH592F/ble/hid/include/kbd_mode.h
+++ b/firmware/CH592F/ble/hid/include/kbd_mode.h
@@ -10,271 +10,304 @@
 #define __KBD_MODE_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "kbd_mode_config.h"
 #include <stdint.h>
 #include <stdbool.h>
 
-/*============================================================================*/
-/* 类型定义 */
-/*============================================================================*/
+    /*============================================================================*/
+    /* 类型定义 */
+    /*============================================================================*/
 
-/**
- * @brief 模式切换回调函数类型
- * @param new_mode 新的工作模式
- */
-typedef void (*kbd_mode_change_cb_t)(kbd_work_mode_t new_mode);
+    /**
+     * @brief 电源管理状态（低功耗层级）
+     */
+    typedef enum
+    {
+        KBD_PM_ACTIVE = 0, /**< 活跃：RGB/BLE/采样正常；BLE 在事件之间由 idleCB 自动睡眠 */
+        KBD_PM_LIGHT = 1,  /**< 浅休眠：RGB 断电 + 停 TMR0 + 停 ADC；BLE 保持 */
+        KBD_PM_DEEP = 2,   /**< 深休眠：LowPower_Shutdown；GPIO 按键唤醒 = 复位 */
+    } kbd_pm_state_t;
 
-/**
- * @brief 连接状态变化回调函数类型
- * @param state 新的连接状态
- */
-typedef void (*kbd_conn_state_cb_t)(kbd_conn_state_t state);
+    /**
+     * @brief 模式切换回调函数类型
+     * @param new_mode 新的工作模式
+     */
+    typedef void (*kbd_mode_change_cb_t)(kbd_work_mode_t new_mode);
 
-/**
- * @brief LED 输出报告回调函数类型
- * @param leds LED 状态位图
- */
-typedef void (*kbd_led_report_cb_t)(uint8_t leds);
+    /**
+     * @brief 连接状态变化回调函数类型
+     * @param state 新的连接状态
+     */
+    typedef void (*kbd_conn_state_cb_t)(kbd_conn_state_t state);
 
-/**
- * @brief 模式管理器回调结构
- */
-typedef struct {
-    kbd_mode_change_cb_t    onModeChange;       /**< 模式切换回调 */
-    kbd_conn_state_cb_t     onConnStateChange;  /**< 连接状态变化回调 */
-    kbd_led_report_cb_t     onLedReport;        /**< LED 报告回调 */
-} kbd_mode_callbacks_t;
+    /**
+     * @brief LED 输出报告回调函数类型
+     * @param leds LED 状态位图
+     */
+    typedef void (*kbd_led_report_cb_t)(uint8_t leds);
 
-/*============================================================================*/
-/* 初始化 API */
-/*============================================================================*/
+    /**
+     * @brief 模式管理器回调结构
+     */
+    typedef struct
+    {
+        kbd_mode_change_cb_t onModeChange;     /**< 模式切换回调 */
+        kbd_conn_state_cb_t onConnStateChange; /**< 连接状态变化回调 */
+        kbd_led_report_cb_t onLedReport;       /**< LED 报告回调 */
+    } kbd_mode_callbacks_t;
 
-/**
- * @brief 初始化模式管理器
- * @param initial_mode 初始工作模式
- * @param pCBs 回调函数指针（可为 NULL）
- * @return 0 成功，其他失败
- */
-int KBD_Mode_Init(kbd_work_mode_t initial_mode, kbd_mode_callbacks_t *pCBs);
+    /*============================================================================*/
+    /* 初始化 API */
+    /*============================================================================*/
 
-/**
- * @brief 模式管理器主循环处理
- * @note  需要在主循环中周期性调用
- */
-void KBD_Mode_Process(void);
+    /**
+     * @brief 初始化模式管理器
+     * @param initial_mode 初始工作模式
+     * @param pCBs 回调函数指针（可为 NULL）
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_Init(kbd_work_mode_t initial_mode, kbd_mode_callbacks_t *pCBs);
 
-/*============================================================================*/
-/* 模式切换 API */
-/*============================================================================*/
+    /**
+     * @brief 模式管理器主循环处理
+     * @note  需要在主循环中周期性调用
+     */
+    void KBD_Mode_Process(void);
 
-/**
- * @brief 切换工作模式
- * @param mode 目标模式
- * @return 0 成功，其他失败
- */
-int KBD_Mode_Switch(kbd_work_mode_t mode);
+    /**
+     * @brief 记录用户活动，用于刷新低功耗空闲计时。
+     */
+    void KBD_Mode_RecordActivity(void);
 
-/**
- * @brief 获取当前工作模式
- * @return 当前模式
- */
-kbd_work_mode_t KBD_Mode_Get(void);
+    /**
+     * @brief 请求退出低功耗，由主循环统一执行恢复。
+     */
+    void KBD_Mode_RequestWake(void);
 
-/**
- * @brief 切换到下一个模式
- * @return 0 成功，其他失败
- */
-int KBD_Mode_Toggle(void);
+    /*============================================================================*/
+    /* 模式切换 API */
+    /*============================================================================*/
 
-/*============================================================================*/
-/* 连接状态 API */
-/*============================================================================*/
+    /**
+     * @brief 切换工作模式
+     * @param mode 目标模式
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_Switch(kbd_work_mode_t mode);
 
-/**
- * @brief 获取当前连接状态
- * @return 连接状态
- */
-kbd_conn_state_t KBD_Mode_GetConnState(void);
+    /**
+     * @brief 获取当前工作模式
+     * @return 当前模式
+     */
+    kbd_work_mode_t KBD_Mode_Get(void);
 
-/**
- * @brief 检查是否已连接（可发送报告）
- * @return true 已连接，false 未连接
- */
-bool KBD_Mode_IsConnected(void);
+    /**
+     * @brief 切换到下一个模式
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_Toggle(void);
 
-/*============================================================================*/
-/* 蓝牙控制 API */
-/*============================================================================*/
+    /*============================================================================*/
+    /* 连接状态 API */
+    /*============================================================================*/
 
-/**
- * @brief 开始蓝牙广播
- * @return 0 成功，其他失败
- */
-int KBD_Mode_BLE_StartAdvertising(void);
+    /**
+     * @brief 获取当前连接状态
+     * @return 连接状态
+     */
+    kbd_conn_state_t KBD_Mode_GetConnState(void);
 
-/**
- * @brief 停止蓝牙广播
- * @return 0 成功，其他失败
- */
-int KBD_Mode_BLE_StopAdvertising(void);
+    /**
+     * @brief 检查是否已连接（可发送报告）
+     * @return true 已连接，false 未连接
+     */
+    bool KBD_Mode_IsConnected(void);
 
-/**
- * @brief 断开蓝牙连接
- * @return 0 成功，其他失败
- */
-int KBD_Mode_BLE_Disconnect(void);
+    /*============================================================================*/
+    /* 蓝牙控制 API */
+    /*============================================================================*/
 
-/**
- * @brief 清除所有蓝牙配对信息，并自动进入可重新配对广播状态
- * @note  仅在 BLE 模式下执行；非 BLE 模式下不执行任何操作
- * @return 0 成功，其他失败
- */
-int KBD_Mode_BLE_ClearBonds(void);
+    /**
+     * @brief 开始蓝牙广播
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_BLE_StartAdvertising(void);
 
-/**
- * @brief 获取蓝牙绑定设备数量
- * @return 绑定设备数量
- */
-uint8_t KBD_Mode_BLE_GetBondCount(void);
+    /**
+     * @brief 停止蓝牙广播
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_BLE_StopAdvertising(void);
 
-/*============================================================================*/
-/* USB 控制 API */
-/*============================================================================*/
+    /**
+     * @brief 断开蓝牙连接
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_BLE_Disconnect(void);
 
-/**
- * @brief 检测 USB 是否已插入
- * @return true USB 已插入，false 未插入
- */
-bool KBD_Mode_USB_IsPlugged(void);
+    /**
+     * @brief 清除所有蓝牙配对信息，并自动进入可重新配对广播状态
+     * @note  仅在 BLE 模式下执行；非 BLE 模式下不执行任何操作
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_BLE_ClearBonds(void);
 
-/**
- * @brief USB 远程唤醒主机
- * @return 0 成功，其他失败
- */
-int KBD_Mode_USB_Wakeup(void);
+    /**
+     * @brief 获取蓝牙绑定设备数量
+     * @return 绑定设备数量
+     */
+    uint8_t KBD_Mode_BLE_GetBondCount(void);
 
-/*============================================================================*/
-/* HID 报告发送 API */
-/*============================================================================*/
+    /*============================================================================*/
+    /* USB 控制 API */
+    /*============================================================================*/
 
-/**
- * @brief 发送键盘报告
- * @param modifier 修饰键位图
- * @param keys 按键数组（最多 6 个）
- * @param key_count 按键数量
- * @return 0 成功，其他失败
- */
-int KBD_Mode_SendKeyboardReport(uint8_t modifier, uint8_t *keys, uint8_t key_count);
+    /**
+     * @brief 检测 USB 是否已插入
+     * @return true USB 已插入，false 未插入
+     */
+    bool KBD_Mode_USB_IsPlugged(void);
 
-/**
- * @brief 发送单个按键（按下+释放）
- * @param modifier 修饰键
- * @param keycode 按键码
- * @return 0 成功，其他失败
- */
-int KBD_Mode_SendKeyPress(uint8_t modifier, uint8_t keycode);
+    /**
+     * @brief USB 远程唤醒主机
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_USB_Wakeup(void);
 
-/**
- * @brief 释放所有键盘按键
- * @return 0 成功，其他失败
- */
-int KBD_Mode_ReleaseAllKeys(void);
+    /*============================================================================*/
+    /* HID 报告发送 API */
+    /*============================================================================*/
 
-/**
- * @brief 发送鼠标报告
- * @param buttons 按钮位图
- * @param x X 轴移动量
- * @param y Y 轴移动量
- * @param wheel 滚轮移动量
- * @return 0 成功，其他失败
- */
-int KBD_Mode_SendMouseReport(uint8_t buttons, int8_t x, int8_t y, int8_t wheel);
+    /**
+     * @brief 发送键盘报告
+     * @param modifier 修饰键位图
+     * @param keys 按键数组（最多 6 个）
+     * @param key_count 按键数量
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_SendKeyboardReport(uint8_t modifier, uint8_t *keys, uint8_t key_count);
 
-/**
- * @brief 发送鼠标点击
- * @param buttons 按钮位图
- * @return 0 成功，其他失败
- */
-int KBD_Mode_SendMouseClick(uint8_t buttons);
+    /**
+     * @brief 发送单个按键（按下+释放）
+     * @param modifier 修饰键
+     * @param keycode 按键码
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_SendKeyPress(uint8_t modifier, uint8_t keycode);
 
-/**
- * @brief 发送多媒体控制报告
- * @param key 多媒体控制码
- * @return 0 成功，其他失败
- */
-int KBD_Mode_SendConsumerReport(uint16_t key);
+    /**
+     * @brief 释放所有键盘按键
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_ReleaseAllKeys(void);
 
-/**
- * @brief 发送多媒体按键（按下+释放）
- * @param key 多媒体控制码
- * @return 0 成功，其他失败
- */
-int KBD_Mode_SendConsumerKey(uint16_t key);
+    /**
+     * @brief 发送鼠标报告
+     * @param buttons 按钮位图
+     * @param x X 轴移动量
+     * @param y Y 轴移动量
+     * @param wheel 滚轮移动量
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_SendMouseReport(uint8_t buttons, int8_t x, int8_t y, int8_t wheel);
 
-/*============================================================================*/
-/* 低功耗 API */
-/*============================================================================*/
+    /**
+     * @brief 发送鼠标点击
+     * @param buttons 按钮位图
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_SendMouseClick(uint8_t buttons);
 
-/**
- * @brief 进入低功耗模式
- */
-void KBD_Mode_EnterSleep(void);
+    /**
+     * @brief 发送多媒体控制报告
+     * @param key 多媒体控制码
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_SendConsumerReport(uint16_t key);
 
-/**
- * @brief 退出低功耗模式
- */
-void KBD_Mode_ExitSleep(void);
+    /**
+     * @brief 发送多媒体按键（按下+释放）
+     * @param key 多媒体控制码
+     * @return 0 成功，其他失败
+     */
+    int KBD_Mode_SendConsumerKey(uint16_t key);
 
-/**
- * @brief 检查是否处于低功耗模式
- * @return true 低功耗模式，false 正常模式
- */
-bool KBD_Mode_IsInSleep(void);
+    /*============================================================================*/
+    /* 低功耗 API */
+    /*============================================================================*/
 
-/*============================================================================*/
-/* LED 状态 API */
-/*============================================================================*/
+    /**
+     * @brief 进入低功耗模式
+     */
+    void KBD_Mode_EnterSleep(void);
 
-/**
- * @brief 获取键盘 LED 状态
- * @return LED 状态位图（NumLock, CapsLock, ScrollLock）
- */
-uint8_t KBD_Mode_GetKeyboardLEDs(void);
+    /**
+     * @brief 退出低功耗模式
+     */
+    void KBD_Mode_ExitSleep(void);
 
-/*============================================================================*/
-/* 兼容旧命名（过渡期使用） */
-/*============================================================================*/
+    /**
+     * @brief 检查是否处于低功耗模式
+     * @return true 低功耗模式，false 正常模式
+     */
+    bool KBD_Mode_IsInSleep(void);
 
-#define dual_mode_callbacks_t           kbd_mode_callbacks_t
+    /**
+     * @brief 当前策略下是否允许进入低功耗。
+     * @return true 允许，false 不允许
+     */
+    bool KBD_Mode_CanEnterLowPower(void);
 
-#define DualMode_Init                   KBD_Mode_Init
-#define DualMode_Process                KBD_Mode_Process
-#define DualMode_SwitchMode             KBD_Mode_Switch
-#define DualMode_GetMode                KBD_Mode_Get
-#define DualMode_ToggleMode             KBD_Mode_Toggle
-#define DualMode_GetConnState           KBD_Mode_GetConnState
-#define DualMode_IsConnected            KBD_Mode_IsConnected
-#define DualMode_BLE_StartAdvertising   KBD_Mode_BLE_StartAdvertising
-#define DualMode_BLE_StopAdvertising    KBD_Mode_BLE_StopAdvertising
-#define DualMode_BLE_Disconnect         KBD_Mode_BLE_Disconnect
-#define DualMode_BLE_ClearBonds         KBD_Mode_BLE_ClearBonds
-#define DualMode_BLE_GetBondCount       KBD_Mode_BLE_GetBondCount
-#define DualMode_USB_IsPlugged          KBD_Mode_USB_IsPlugged
-#define DualMode_USB_Wakeup             KBD_Mode_USB_Wakeup
-#define DualMode_SendKeyboardReport     KBD_Mode_SendKeyboardReport
-#define DualMode_SendKeyPress           KBD_Mode_SendKeyPress
-#define DualMode_ReleaseAllKeys         KBD_Mode_ReleaseAllKeys
-#define DualMode_SendMouseReport        KBD_Mode_SendMouseReport
-#define DualMode_SendMouseClick         KBD_Mode_SendMouseClick
-#define DualMode_SendConsumerReport     KBD_Mode_SendConsumerReport
-#define DualMode_SendConsumerKey        KBD_Mode_SendConsumerKey
-#define DualMode_EnterSleep             KBD_Mode_EnterSleep
-#define DualMode_ExitSleep              KBD_Mode_ExitSleep
-#define DualMode_IsInSleep              KBD_Mode_IsInSleep
-#define DualMode_GetKeyboardLEDs        KBD_Mode_GetKeyboardLEDs
+    /**
+     * @brief 获取当前电源管理状态
+     */
+    kbd_pm_state_t KBD_Mode_GetPMState(void);
+
+    /*============================================================================*/
+    /* LED 状态 API */
+    /*============================================================================*/
+
+    /**
+     * @brief 获取键盘 LED 状态
+     * @return LED 状态位图（NumLock, CapsLock, ScrollLock）
+     */
+    uint8_t KBD_Mode_GetKeyboardLEDs(void);
+
+    /*============================================================================*/
+    /* 兼容旧命名（过渡期使用） */
+    /*============================================================================*/
+
+#define dual_mode_callbacks_t kbd_mode_callbacks_t
+
+#define DualMode_Init KBD_Mode_Init
+#define DualMode_Process KBD_Mode_Process
+#define DualMode_SwitchMode KBD_Mode_Switch
+#define DualMode_GetMode KBD_Mode_Get
+#define DualMode_ToggleMode KBD_Mode_Toggle
+#define DualMode_GetConnState KBD_Mode_GetConnState
+#define DualMode_IsConnected KBD_Mode_IsConnected
+#define DualMode_BLE_StartAdvertising KBD_Mode_BLE_StartAdvertising
+#define DualMode_BLE_StopAdvertising KBD_Mode_BLE_StopAdvertising
+#define DualMode_BLE_Disconnect KBD_Mode_BLE_Disconnect
+#define DualMode_BLE_ClearBonds KBD_Mode_BLE_ClearBonds
+#define DualMode_BLE_GetBondCount KBD_Mode_BLE_GetBondCount
+#define DualMode_USB_IsPlugged KBD_Mode_USB_IsPlugged
+#define DualMode_USB_Wakeup KBD_Mode_USB_Wakeup
+#define DualMode_SendKeyboardReport KBD_Mode_SendKeyboardReport
+#define DualMode_SendKeyPress KBD_Mode_SendKeyPress
+#define DualMode_ReleaseAllKeys KBD_Mode_ReleaseAllKeys
+#define DualMode_SendMouseReport KBD_Mode_SendMouseReport
+#define DualMode_SendMouseClick KBD_Mode_SendMouseClick
+#define DualMode_SendConsumerReport KBD_Mode_SendConsumerReport
+#define DualMode_SendConsumerKey KBD_Mode_SendConsumerKey
+#define DualMode_EnterSleep KBD_Mode_EnterSleep
+#define DualMode_ExitSleep KBD_Mode_ExitSleep
+#define DualMode_IsInSleep KBD_Mode_IsInSleep
+#define DualMode_GetKeyboardLEDs KBD_Mode_GetKeyboardLEDs
 
 #ifdef __cplusplus
 }

--- a/firmware/CH592F/ble/hid/include/kbd_mode_config.h
+++ b/firmware/CH592F/ble/hid/include/kbd_mode_config.h
@@ -124,14 +124,14 @@ extern "C"
 /** 启用低功耗模式 */
 #define KBD_LOW_POWER_ENABLE 1
 
-/** 进入 LIGHT 休眠的空闲时间（毫秒）：RGB 断电 + TMR0 停 + 电池分压关闭，BLE 仍保持 */
+/** 兼容旧宏：当前实际超时以 DataFlash / Studio 配置为准 */
 #ifndef KBD_LIGHT_SLEEP_TIMEOUT_MS
-#define KBD_LIGHT_SLEEP_TIMEOUT_MS 3000u /**< 3 秒（测试值；生产建议 30000 = 30 秒） */
+#define KBD_LIGHT_SLEEP_TIMEOUT_MS 60000u /**< LIGHT 默认 1 分钟 */
 #endif
 
-/** 进入 DEEP 休眠的空闲时间（毫秒）：LowPower_Shutdown，按键唤醒等同复位 */
+/** 兼容旧宏：当前实际超时以 DataFlash / Studio 配置为准 */
 #ifndef KBD_DEEP_SLEEP_TIMEOUT_MS
-#define KBD_DEEP_SLEEP_TIMEOUT_MS 10000u /**< 10 秒（测试值；生产建议 600000 = 10 分钟） */
+#define KBD_DEEP_SLEEP_TIMEOUT_MS 120000u /**< 总空闲默认 2 分钟 */
 #endif
 
 /** 兼容旧命名 */

--- a/firmware/CH592F/ble/hid/include/kbd_mode_config.h
+++ b/firmware/CH592F/ble/hid/include/kbd_mode_config.h
@@ -10,44 +10,47 @@
 #define __KBD_MODE_CONFIG_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include "CH59x_common.h"
 
-/*============================================================================*/
-/* 工作模式定义 */
-/*============================================================================*/
+    /*============================================================================*/
+    /* 工作模式定义 */
+    /*============================================================================*/
 
-typedef enum {
-    KBD_WORK_MODE_USB = 0,      /**< USB 有线模式 */
-    KBD_WORK_MODE_BLE = 1,      /**< 蓝牙无线模式 */
-    /* KBD_WORK_MODE_2G4 = 2,   预留：2.4G 无线模式 */
-} kbd_work_mode_t;
+    typedef enum
+    {
+        KBD_WORK_MODE_USB = 0, /**< USB 有线模式 */
+        KBD_WORK_MODE_BLE = 1, /**< 蓝牙无线模式 */
+        /* KBD_WORK_MODE_2G4 = 2,   预留：2.4G 无线模式 */
+    } kbd_work_mode_t;
 
-/*============================================================================*/
-/* 连接状态定义 */
-/*============================================================================*/
+    /*============================================================================*/
+    /* 连接状态定义 */
+    /*============================================================================*/
 
-typedef enum {
-    KBD_CONN_DISCONNECTED = 0,  /**< 未连接 */
-    KBD_CONN_ADVERTISING  = 1,  /**< 广播中（仅蓝牙） */
-    KBD_CONN_CONNECTED    = 2,  /**< 已连接 */
-    KBD_CONN_SUSPENDED    = 3,  /**< 挂起 */
-} kbd_conn_state_t;
+    typedef enum
+    {
+        KBD_CONN_DISCONNECTED = 0, /**< 未连接 */
+        KBD_CONN_ADVERTISING = 1,  /**< 广播中（仅蓝牙） */
+        KBD_CONN_CONNECTED = 2,    /**< 已连接 */
+        KBD_CONN_SUSPENDED = 3,    /**< 挂起 */
+    } kbd_conn_state_t;
 
 /*============================================================================*/
 /* 模式切换配置 */
 /*============================================================================*/
 
 /** 长按 FN 键切换模式的阈值（毫秒） */
-#define KBD_MODE_SWITCH_HOLD_MS         800
+#define KBD_MODE_SWITCH_HOLD_MS 800
 
 /** 切换到蓝牙后自动开始广播 */
-#define KBD_AUTO_START_ADVERTISING      1
+#define KBD_AUTO_START_ADVERTISING 1
 
 /** USB 插入时自动切换到 USB 模式（默认启用，开机即为 USB 模式） */
-#define KBD_AUTO_SWITCH_TO_USB_ON_PLUG  1
+#define KBD_AUTO_SWITCH_TO_USB_ON_PLUG 1
 
 /*============================================================================*/
 /* 蓝牙配置 */
@@ -55,116 +58,126 @@ typedef enum {
 
 /** 型号名称（由 CMake 注入，默认 5KEY） */
 #ifndef KBD_MODEL_NAME
-#define KBD_MODEL_NAME                 "5KEY"
+#define KBD_MODEL_NAME "5KEY"
 #endif
 
 /** 统一设备名称（USB/BLE 共用） */
 #ifndef KBD_DEVICE_NAME
-#define KBD_DEVICE_NAME                "BinaryKeyboard" KBD_MODEL_NAME
+#define KBD_DEVICE_NAME "BinaryKeyboard" KBD_MODEL_NAME
 #endif
 
 /** 设备名称 */
-#define KBD_BLE_DEVICE_NAME             KBD_DEVICE_NAME
-#define KBD_BLE_DEVICE_NAME_LEN         (sizeof(KBD_BLE_DEVICE_NAME) - 1)
+#define KBD_BLE_DEVICE_NAME KBD_DEVICE_NAME
+#define KBD_BLE_DEVICE_NAME_LEN (sizeof(KBD_BLE_DEVICE_NAME) - 1)
 
 /** 广播参数（单位：0.625ms） */
-#define KBD_BLE_ADV_INT_MIN             48      /**< 30ms */
-#define KBD_BLE_ADV_INT_MAX             80      /**< 50ms */
-#define KBD_BLE_ADV_TIMEOUT             60      /**< 60秒超时 */
+#define KBD_BLE_ADV_INT_MIN 48 /**< 30ms */
+#define KBD_BLE_ADV_INT_MAX 80 /**< 50ms */
+#define KBD_BLE_ADV_TIMEOUT 60 /**< 60秒超时 */
 
 /** 连接参数（单位：1.25ms） */
-#define KBD_BLE_CONN_INT_MIN            8       /**< 10ms */
-#define KBD_BLE_CONN_INT_MAX            8       /**< 10ms */
-#define KBD_BLE_SLAVE_LATENCY           20      /**< 从机延迟 */
-#define KBD_BLE_CONN_TIMEOUT            500     /**< 5秒超时 */
+#define KBD_BLE_CONN_INT_MIN 8   /**< 10ms */
+#define KBD_BLE_CONN_INT_MAX 8   /**< 10ms */
+#define KBD_BLE_SLAVE_LATENCY 20 /**< 从机延迟 */
+#define KBD_BLE_CONN_TIMEOUT 500 /**< 5秒超时 */
 
 /** 配对模式 */
-#define KBD_BLE_PAIRING_MODE            GAPBOND_PAIRING_MODE_WAIT_FOR_REQ
-#define KBD_BLE_MITM_MODE               FALSE
-#define KBD_BLE_BONDING_MODE            TRUE
-#define KBD_BLE_IO_CAPABILITIES         GAPBOND_IO_CAP_NO_INPUT_NO_OUTPUT
+#define KBD_BLE_PAIRING_MODE GAPBOND_PAIRING_MODE_WAIT_FOR_REQ
+#define KBD_BLE_MITM_MODE FALSE
+#define KBD_BLE_BONDING_MODE TRUE
+#define KBD_BLE_IO_CAPABILITIES GAPBOND_IO_CAP_NO_INPUT_NO_OUTPUT
 
 /** HID 空闲超时（毫秒），0 表示不超时 */
-#define KBD_BLE_HID_IDLE_TIMEOUT        60000
+#define KBD_BLE_HID_IDLE_TIMEOUT 60000
 
 /*============================================================================*/
 /* USB 配置 */
 /*============================================================================*/
 
 /** USB VID/PID */
-#define KBD_USB_VENDOR_ID               0x413D
-#define KBD_USB_PRODUCT_ID              0x2107
+#define KBD_USB_VENDOR_ID 0x413D
+#define KBD_USB_PRODUCT_ID 0x2107
 
 /** USB 设备字符串 */
-#define KBD_USB_MANUFACTURER_STRING     "MeowKJ"
-#define KBD_USB_PRODUCT_STRING          KBD_DEVICE_NAME
+#define KBD_USB_MANUFACTURER_STRING "MeowKJ"
+#define KBD_USB_PRODUCT_STRING KBD_DEVICE_NAME
 
 /*============================================================================*/
 /* HID 报告配置 */
 /*============================================================================*/
 
 /** HID 报告 ID */
-#define KBD_HID_RPT_ID_KEYBOARD         0       /**< 键盘报告 ID */
-#define KBD_HID_RPT_ID_MOUSE            1       /**< 鼠标报告 ID */
-#define KBD_HID_RPT_ID_CONSUMER         2       /**< 多媒体报告 ID */
-#define KBD_HID_RPT_ID_LED_OUT          0       /**< LED 输出报告 ID */
+#define KBD_HID_RPT_ID_KEYBOARD 0 /**< 键盘报告 ID */
+#define KBD_HID_RPT_ID_MOUSE 1    /**< 鼠标报告 ID */
+#define KBD_HID_RPT_ID_CONSUMER 2 /**< 多媒体报告 ID */
+#define KBD_HID_RPT_ID_LED_OUT 0  /**< LED 输出报告 ID */
 
 /** 报告长度 */
-#define KBD_HID_KEYBOARD_REPORT_LEN     8       /**< 键盘报告长度 */
-#define KBD_HID_MOUSE_REPORT_LEN        4       /**< 鼠标报告长度 */
-#define KBD_HID_CONSUMER_REPORT_LEN     2       /**< 多媒体报告长度 */
+#define KBD_HID_KEYBOARD_REPORT_LEN 8 /**< 键盘报告长度 */
+#define KBD_HID_MOUSE_REPORT_LEN 4    /**< 鼠标报告长度 */
+#define KBD_HID_CONSUMER_REPORT_LEN 2 /**< 多媒体报告长度 */
 
 /*============================================================================*/
 /* 低功耗配置 */
 /*============================================================================*/
 
 /** 启用低功耗模式 */
-#define KBD_LOW_POWER_ENABLE            1
+#define KBD_LOW_POWER_ENABLE 1
 
-/** 空闲进入低功耗的时间（毫秒） */
-#define KBD_IDLE_SLEEP_TIMEOUT_MS       30000   /**< 30秒无操作进入休眠 */
+/** 进入 LIGHT 休眠的空闲时间（毫秒）：RGB 断电 + TMR0 停 + 电池分压关闭，BLE 仍保持 */
+#ifndef KBD_LIGHT_SLEEP_TIMEOUT_MS
+#define KBD_LIGHT_SLEEP_TIMEOUT_MS 3000u /**< 3 秒（测试值；生产建议 30000 = 30 秒） */
+#endif
+
+/** 进入 DEEP 休眠的空闲时间（毫秒）：LowPower_Shutdown，按键唤醒等同复位 */
+#ifndef KBD_DEEP_SLEEP_TIMEOUT_MS
+#define KBD_DEEP_SLEEP_TIMEOUT_MS 10000u /**< 10 秒（测试值；生产建议 600000 = 10 分钟） */
+#endif
+
+/** 兼容旧命名 */
+#define KBD_IDLE_SLEEP_TIMEOUT_MS KBD_LIGHT_SLEEP_TIMEOUT_MS
 
 /** 唤醒方式 */
-#define KBD_WAKEUP_BY_KEY               1       /**< 按键唤醒 */
-#define KBD_WAKEUP_BY_USB               1       /**< USB 插入唤醒 */
+#define KBD_WAKEUP_BY_KEY 1 /**< 按键唤醒 */
+#define KBD_WAKEUP_BY_USB 1 /**< USB 插入唤醒 */
 
 /*============================================================================*/
 /* 兼容旧命名（过渡期使用） */
 /*============================================================================*/
 
 /* 工作模式 */
-#define work_mode_t                     kbd_work_mode_t
-#define WORK_MODE_USB                   KBD_WORK_MODE_USB
-#define WORK_MODE_BLE                   KBD_WORK_MODE_BLE
+#define work_mode_t kbd_work_mode_t
+#define WORK_MODE_USB KBD_WORK_MODE_USB
+#define WORK_MODE_BLE KBD_WORK_MODE_BLE
 
 /* 连接状态 */
-#define conn_state_t                    kbd_conn_state_t
-#define CONN_STATE_DISCONNECTED         KBD_CONN_DISCONNECTED
-#define CONN_STATE_ADVERTISING          KBD_CONN_ADVERTISING
-#define CONN_STATE_CONNECTED            KBD_CONN_CONNECTED
-#define CONN_STATE_SUSPENDED            KBD_CONN_SUSPENDED
+#define conn_state_t kbd_conn_state_t
+#define CONN_STATE_DISCONNECTED KBD_CONN_DISCONNECTED
+#define CONN_STATE_ADVERTISING KBD_CONN_ADVERTISING
+#define CONN_STATE_CONNECTED KBD_CONN_CONNECTED
+#define CONN_STATE_SUSPENDED KBD_CONN_SUSPENDED
 
 /* 配置宏 */
-#define AUTO_START_ADVERTISING          KBD_AUTO_START_ADVERTISING
-#define AUTO_SWITCH_TO_USB_ON_PLUG      KBD_AUTO_SWITCH_TO_USB_ON_PLUG
-#define HID_KEYBOARD_REPORT_LEN         KBD_HID_KEYBOARD_REPORT_LEN
-#define HID_MOUSE_REPORT_LEN            KBD_HID_MOUSE_REPORT_LEN
+#define AUTO_START_ADVERTISING KBD_AUTO_START_ADVERTISING
+#define AUTO_SWITCH_TO_USB_ON_PLUG KBD_AUTO_SWITCH_TO_USB_ON_PLUG
+#define HID_KEYBOARD_REPORT_LEN KBD_HID_KEYBOARD_REPORT_LEN
+#define HID_MOUSE_REPORT_LEN KBD_HID_MOUSE_REPORT_LEN
 
 /* BLE 配置兼容 */
-#define BLE_DEVICE_NAME                 KBD_BLE_DEVICE_NAME
-#define BLE_DEVICE_NAME_LEN             KBD_BLE_DEVICE_NAME_LEN
-#define BLE_ADV_INT_MIN                 KBD_BLE_ADV_INT_MIN
-#define BLE_ADV_INT_MAX                 KBD_BLE_ADV_INT_MAX
-#define BLE_ADV_TIMEOUT                 KBD_BLE_ADV_TIMEOUT
-#define BLE_CONN_INT_MIN                KBD_BLE_CONN_INT_MIN
-#define BLE_CONN_INT_MAX                KBD_BLE_CONN_INT_MAX
-#define BLE_SLAVE_LATENCY               KBD_BLE_SLAVE_LATENCY
-#define BLE_CONN_TIMEOUT                KBD_BLE_CONN_TIMEOUT
-#define BLE_PAIRING_MODE                KBD_BLE_PAIRING_MODE
-#define BLE_MITM_MODE                   KBD_BLE_MITM_MODE
-#define BLE_BONDING_MODE                KBD_BLE_BONDING_MODE
-#define BLE_IO_CAPABILITIES             KBD_BLE_IO_CAPABILITIES
-#define BLE_HID_IDLE_TIMEOUT            KBD_BLE_HID_IDLE_TIMEOUT
+#define BLE_DEVICE_NAME KBD_BLE_DEVICE_NAME
+#define BLE_DEVICE_NAME_LEN KBD_BLE_DEVICE_NAME_LEN
+#define BLE_ADV_INT_MIN KBD_BLE_ADV_INT_MIN
+#define BLE_ADV_INT_MAX KBD_BLE_ADV_INT_MAX
+#define BLE_ADV_TIMEOUT KBD_BLE_ADV_TIMEOUT
+#define BLE_CONN_INT_MIN KBD_BLE_CONN_INT_MIN
+#define BLE_CONN_INT_MAX KBD_BLE_CONN_INT_MAX
+#define BLE_SLAVE_LATENCY KBD_BLE_SLAVE_LATENCY
+#define BLE_CONN_TIMEOUT KBD_BLE_CONN_TIMEOUT
+#define BLE_PAIRING_MODE KBD_BLE_PAIRING_MODE
+#define BLE_MITM_MODE KBD_BLE_MITM_MODE
+#define BLE_BONDING_MODE KBD_BLE_BONDING_MODE
+#define BLE_IO_CAPABILITIES KBD_BLE_IO_CAPABILITIES
+#define BLE_HID_IDLE_TIMEOUT KBD_BLE_HID_IDLE_TIMEOUT
 
 #ifdef __cplusplus
 }

--- a/firmware/CH592F/ble/hid/src/ble_hid.c
+++ b/firmware/CH592F/ble/hid/src/ble_hid.c
@@ -16,6 +16,8 @@
 #include "kbd_battery.h"
 #include <string.h>
 
+#define TAG "BLE"
+
 /* ==================== 常量定义 ==================== */
 
 // 参数更新延迟（625us 单位）
@@ -499,4 +501,3 @@ static void BLE_HID_StateCallback (gapRole_States_t newState, gapRoleEvent_t *pE
         g_pCallbacks->onStateChange (newState);
     }
 }
-

--- a/firmware/CH592F/ble/hid/src/ble_hid.c
+++ b/firmware/CH592F/ble/hid/src/ble_hid.c
@@ -40,6 +40,7 @@ static gapRole_States_t g_ble_state = GAPROLE_INIT;
 static uint16_t g_conn_handle = GAP_CONNHANDLE_INIT;
 static ble_hid_callbacks_t *g_pCallbacks = NULL;
 static uint8_t g_keyboard_leds = 0;
+static bool g_auto_resume_advertising = true;
 // HID 配置
 static hidDevCfg_t g_hidDevCfg = {
     BLE_HID_IDLE_TIMEOUT,  // 空闲超时
@@ -76,6 +77,7 @@ static void BLE_HID_EvtCallback (uint8_t evt);
 static void BLE_HID_StateCallback (gapRole_States_t newState, gapRoleEvent_t *pEvent);
 static void BLE_HID_BuildDeviceNameData (void);
 static uint8_t BLE_HID_ReadBatteryLevel (void);
+static void BLE_HID_ApplyAdvertisingParams (void);
 
 // HID 设备回调
 static hidDevCB_t g_hidDevCallbacks = {
@@ -138,10 +140,17 @@ static uint8_t BLE_HID_ReadBatteryLevel (void) {
     return KBD_Battery_GetLevel();
 }
 
+static void BLE_HID_ApplyAdvertisingParams (void) {
+    GAP_SetParamValue (TGAP_DISC_ADV_INT_MIN, BLE_ADV_INT_MIN);
+    GAP_SetParamValue (TGAP_DISC_ADV_INT_MAX, BLE_ADV_INT_MAX);
+    GAP_SetParamValue (TGAP_LIM_ADV_TIMEOUT, BLE_ADV_TIMEOUT);
+}
+
 /* ==================== 初始化实现 ==================== */
 
 int BLE_HID_Init (ble_hid_callbacks_t *pCBs) {
     g_pCallbacks = pCBs;
+    g_auto_resume_advertising = true;
     BLE_HID_BuildDeviceNameData();
 
     // 注册 TMOS 任务
@@ -150,6 +159,7 @@ int BLE_HID_Init (ble_hid_callbacks_t *pCBs) {
     // 设置 GAP 角色参数
     {
         uint8_t enable = TRUE;  // BLE 模式自动开始广播（WCH Application 示例方式）
+        BLE_HID_ApplyAdvertisingParams();
         GAPRole_SetParameter (GAPROLE_ADVERT_ENABLED, sizeof (uint8_t), &enable);
         GAPRole_SetParameter (GAPROLE_ADVERT_DATA, sizeof (g_advertData), g_advertData);
         GAPRole_SetParameter (GAPROLE_SCAN_RSP_DATA, g_scanRspDataLen, g_scanRspData);
@@ -268,10 +278,8 @@ static void BLE_HID_ProcessTMOSMsg (tmos_event_hdr_t *pMsg) {
 /* ==================== 连接管理实现 ==================== */
 
 int BLE_HID_StartAdvertising (void) {
-    // 设置广播参数
-    GAP_SetParamValue (TGAP_DISC_ADV_INT_MIN, BLE_ADV_INT_MIN);
-    GAP_SetParamValue (TGAP_DISC_ADV_INT_MAX, BLE_ADV_INT_MAX);
-    GAP_SetParamValue (TGAP_LIM_ADV_TIMEOUT, BLE_ADV_TIMEOUT);
+    g_auto_resume_advertising = true;
+    BLE_HID_ApplyAdvertisingParams();
 
     // 开始广播
     uint8_t enable = TRUE;
@@ -292,6 +300,11 @@ int BLE_HID_StopAdvertising (void) {
 
     LOG_I (TAG, "Stop advertising");
     return 0;
+}
+
+void BLE_HID_SetAutoResumeAdvertising (bool enable) {
+    g_auto_resume_advertising = enable;
+    LOG_I (TAG, "Auto advertising=%d", enable ? 1 : 0);
 }
 
 int BLE_HID_Disconnect (void) {
@@ -481,10 +494,11 @@ static void BLE_HID_StateCallback (gapRole_States_t newState, gapRoleEvent_t *pE
                    pEvent->linkTerminate.reason);
         }
 
-        // 自动恢复广播
-        {
+        if (g_auto_resume_advertising) {
             uint8_t enable = TRUE;
             GAPRole_SetParameter (GAPROLE_ADVERT_ENABLED, sizeof (uint8_t), &enable);
+        } else {
+            LOG_I (TAG, "Advertising restart suppressed");
         }
         break;
 

--- a/firmware/CH592F/ble/hid/src/kbd_mode.c
+++ b/firmware/CH592F/ble/hid/src/kbd_mode.c
@@ -24,6 +24,7 @@
 
 #define TAG "MODE"
 #define BLE_BOND_CLEAR_SETTLE_MS 100
+#define BLE_DEEP_SLEEP_DISCONNECT_SETTLE_MS 30u
 #define KBD_LOW_BATTERY_INDICATOR_LEVEL 10u
 #define KBD_SLEEP_ENTRY_FLASH_COUNT 3u
 #define KBD_SLEEP_ENTRY_FLASH_ON_MS 90u
@@ -63,6 +64,8 @@ static void KBD_Mode_BLE_LedCallback(uint8_t leds);
 static uint32_t KBD_Mode_GetNow(void);
 static void KBD_Mode_RecordActivityInternal(void);
 static uint32_t KBD_Mode_GetIdleMs(void);
+static uint32_t KBD_Mode_GetLightSleepTimeoutMs(void);
+static uint32_t KBD_Mode_GetDeepSleepTimeoutMs(void);
 static void KBD_Mode_CancelDeepSleepCheck(void);
 static void KBD_Mode_ArmDeepSleepCheck(void);
 static bool KBD_Mode_IsDeepSleepCheckDue(void);
@@ -154,6 +157,8 @@ void KBD_Mode_Process(void)
 
     if (g_pm_state == KBD_PM_LIGHT)
     {
+        uint32_t deep_timeout_ms = KBD_Mode_GetDeepSleepTimeoutMs();
+
         /*
          * LIGHT 期间由我们主动执行 CPU idle。
          * 这里不能依赖 BLE idleCB 自动 Sleep，否则会在 RGB 活跃期打断 TMR1/DMA，
@@ -165,14 +170,17 @@ void KBD_Mode_Process(void)
             return;
         }
 
-        if (KBD_Mode_CanEnterDeepSleep() &&
-            KBD_Mode_GetIdleMs() >= KBD_DEEP_SLEEP_TIMEOUT_MS)
+        if ((deep_timeout_ms > 0u) &&
+            KBD_Mode_CanEnterDeepSleep() &&
+            (KBD_Mode_GetIdleMs() >= deep_timeout_ms))
         {
             KBD_Mode_EnterDeepSleep();
             /* 不返回（Shutdown 后唤醒等价复位） */
         }
 
-        if (KBD_Mode_IsDeepSleepCheckDue() && KBD_Mode_CanEnterDeepSleep())
+        if ((deep_timeout_ms > 0u) &&
+            KBD_Mode_IsDeepSleepCheckDue() &&
+            KBD_Mode_CanEnterDeepSleep())
         {
             KBD_Mode_EnterDeepSleep();
         }
@@ -182,8 +190,9 @@ void KBD_Mode_Process(void)
     }
 
     /* ACTIVE */
-    if (KBD_Mode_CanEnterLowPower() &&
-        KBD_Mode_GetIdleMs() >= KBD_LIGHT_SLEEP_TIMEOUT_MS)
+    if ((KBD_Mode_GetLightSleepTimeoutMs() > 0u) &&
+        KBD_Mode_CanEnterLowPower() &&
+        (KBD_Mode_GetIdleMs() >= KBD_Mode_GetLightSleepTimeoutMs()))
     {
         KBD_Mode_EnterLightSleep();
         return;
@@ -560,7 +569,7 @@ bool KBD_Mode_CanEnterLowPower(void)
     return true;
 }
 
-/** 进入 DEEP 需要额外条件：不要让深休眠打断已有连接。 */
+/** 进入 DEEP 需要额外条件：BLE 模式允许主动断链后再 Shutdown。 */
 static bool KBD_Mode_CanEnterDeepSleep(void)
 {
     if (!KBD_Mode_CanEnterLowPower())
@@ -568,14 +577,8 @@ static bool KBD_Mode_CanEnterDeepSleep(void)
         return false;
     }
 
-    /* USB 线已插入（即使未枚举）时不 Shutdown，避免用户拔插跟 reset 竞争 */
-    if (KBD_Mode_USB_IsPlugged())
-    {
-        return false;
-    }
-
-    /* BLE 已连接时不 Shutdown，避免无谓的断开重连 */
-    if (g_conn_state == KBD_CONN_CONNECTED)
+    /* 仅在 USB 已真正完成枚举时阻止 Shutdown；单纯供电不再拦休眠。 */
+    if (KBD_Mode_USB_HasProtocolHandshake())
     {
         return false;
     }
@@ -633,15 +636,28 @@ static void KBD_Mode_ExitLightSleep(void)
 
 static void KBD_Mode_EnterDeepSleep(void)
 {
+    if (g_pm_state == KBD_PM_ACTIVE)
+    {
+        KBD_Mode_PlaySleepEntryAnimation();
+        KBD_Mode_ReleaseAllKeys();
+        KBD_RGB_SetSchedulerEnabled(false);
+        KBD_RGB_SetLowPower(true);
+        KBD_Battery_Suspend();
+        Key_EnterSleep();
+    }
+
     LOG_I(TAG, "enter DEEP (shutdown)");
     g_pm_state = KBD_PM_DEEP;
+    g_wake_requested = false;
     KBD_Mode_CancelDeepSleepCheck();
 
-    /* BLE 主动断开 + 停广播（CanEnterDeepSleep 已排除 CONNECTED，这里是兜底） */
+    /* BLE 模式下先主动断开并抑制自动恢复广播，再执行深睡。 */
     if (g_current_mode == KBD_WORK_MODE_BLE)
     {
-        BLE_HID_StopAdvertising();
+        BLE_HID_SetAutoResumeAdvertising(false);
         BLE_HID_Disconnect();
+        BLE_HID_StopAdvertising();
+        mDelaymS(BLE_DEEP_SLEEP_DISCONNECT_SETTLE_MS);
     }
 
     /* 持久化（Shutdown 之后 RAM 不保留） */
@@ -747,6 +763,30 @@ static uint32_t KBD_Mode_GetIdleMs(void)
     return (uint32_t)(((uint64_t)elapsed * 1000u + (KBD_RTC_FREQ_HZ / 2u)) / KBD_RTC_FREQ_HZ);
 }
 
+static uint32_t KBD_Mode_GetLightSleepTimeoutMs(void)
+{
+    const kbd_system_config_t *sys = KBD_GetSystemConfig();
+
+    if (sys->auto_sleep_min == 0u)
+    {
+        return 0u;
+    }
+
+    return (uint32_t)sys->auto_sleep_min * 60000u;
+}
+
+static uint32_t KBD_Mode_GetDeepSleepTimeoutMs(void)
+{
+    const kbd_system_config_t *sys = KBD_GetSystemConfig();
+
+    if ((sys->auto_sleep_min == 0u) || (sys->deep_sleep_min == 0u))
+    {
+        return 0u;
+    }
+
+    return ((uint32_t)sys->auto_sleep_min + (uint32_t)sys->deep_sleep_min) * 60000u;
+}
+
 static void KBD_Mode_CancelDeepSleepCheck(void)
 {
     RTC_ModeFunDisable(RTC_TRIG_MODE);
@@ -757,11 +797,21 @@ static void KBD_Mode_CancelDeepSleepCheck(void)
 
 static void KBD_Mode_ArmDeepSleepCheck(void)
 {
+    uint32_t deep_timeout_ms = KBD_Mode_GetDeepSleepTimeoutMs();
     uint32_t idle_ms = KBD_Mode_GetIdleMs();
-    uint32_t remain_ms = (idle_ms >= KBD_DEEP_SLEEP_TIMEOUT_MS)
-                             ? 1u
-                             : (KBD_DEEP_SLEEP_TIMEOUT_MS - idle_ms);
-    uint32_t rtc_cycles = (uint32_t)(((uint64_t)remain_ms * KBD_RTC_FREQ_HZ + 999u) / 1000u);
+    uint32_t remain_ms;
+    uint32_t rtc_cycles;
+
+    if (deep_timeout_ms == 0u)
+    {
+        KBD_Mode_CancelDeepSleepCheck();
+        return;
+    }
+
+    remain_ms = (idle_ms >= deep_timeout_ms)
+                    ? 1u
+                    : (deep_timeout_ms - idle_ms);
+    rtc_cycles = (uint32_t)(((uint64_t)remain_ms * KBD_RTC_FREQ_HZ + 999u) / 1000u);
 
     if (rtc_cycles == 0u)
     {

--- a/firmware/CH592F/ble/hid/src/kbd_mode.c
+++ b/firmware/CH592F/ble/hid/src/kbd_mode.c
@@ -11,14 +11,29 @@
 
 #include "kbd_mode.h"
 #include "ble_hid.h"
+#include "kbd_battery.h"
+#include "kbd_rgb.h"
 #include "usb_device.h"
 #include "usb_hid.h"
 #include "kbd_storage.h"
+#include "key.h"
 #include "debug.h"
+#include "ws2812.h"
+#include "ble_rtc.h"
 #include <string.h>
 
 #define TAG "MODE"
 #define BLE_BOND_CLEAR_SETTLE_MS 100
+#define KBD_LOW_BATTERY_INDICATOR_LEVEL 10u
+#define KBD_SLEEP_ENTRY_FLASH_COUNT 3u
+#define KBD_SLEEP_ENTRY_FLASH_ON_MS 90u
+#define KBD_SLEEP_ENTRY_FLASH_OFF_MS 70u
+
+#if defined(CLK_OSC32K) && (CLK_OSC32K == 1)
+#define KBD_RTC_FREQ_HZ 32000u
+#else
+#define KBD_RTC_FREQ_HZ 32768u
+#endif
 
 /*============================================================================*/
 /* 私有变量 */
@@ -28,8 +43,10 @@ static kbd_work_mode_t g_current_mode = KBD_WORK_MODE_USB;
 static kbd_conn_state_t g_conn_state = KBD_CONN_DISCONNECTED;
 static kbd_mode_callbacks_t *g_pCallbacks = NULL;
 static uint8_t g_keyboard_leds = 0;
-static bool g_is_sleeping = false;
+static kbd_pm_state_t g_pm_state = KBD_PM_ACTIVE;
 static bool g_mode_switching = false;
+static uint32_t g_last_activity_tick = 0;
+static bool g_wake_requested = false;
 
 /** 报告缓冲区 */
 static uint8_t g_kbd_report[KBD_HID_KEYBOARD_REPORT_LEN];
@@ -43,6 +60,20 @@ static uint16_t g_consumer_report;
 static void KBD_Mode_UpdateConnState(kbd_conn_state_t state);
 static void KBD_Mode_BLE_StateCallback(gapRole_States_t newState);
 static void KBD_Mode_BLE_LedCallback(uint8_t leds);
+static uint32_t KBD_Mode_GetNow(void);
+static void KBD_Mode_RecordActivityInternal(void);
+static uint32_t KBD_Mode_GetIdleMs(void);
+static void KBD_Mode_CancelDeepSleepCheck(void);
+static void KBD_Mode_ArmDeepSleepCheck(void);
+static bool KBD_Mode_IsDeepSleepCheckDue(void);
+static bool KBD_Mode_USB_HasProtocolHandshake(void);
+static void KBD_Mode_PlaySleepEntryAnimation(void);
+static kbd_state_t KBD_Mode_ResolveIndicatorState(void);
+static void KBD_Mode_RefreshIndicatorState(void);
+static void KBD_Mode_EnterLightSleep(void);
+static void KBD_Mode_ExitLightSleep(void);
+static void KBD_Mode_EnterDeepSleep(void);
+static bool KBD_Mode_CanEnterDeepSleep(void);
 
 /*============================================================================*/
 /* BLE 回调 */
@@ -64,8 +95,12 @@ int KBD_Mode_Init(kbd_work_mode_t initial_mode, kbd_mode_callbacks_t *pCBs)
     g_pCallbacks = pCBs;
     g_current_mode = initial_mode;
     g_conn_state = KBD_CONN_DISCONNECTED;
-    g_is_sleeping = false;
+    g_pm_state = KBD_PM_ACTIVE;
     g_mode_switching = false;
+    g_last_activity_tick = KBD_Mode_GetNow();
+    g_wake_requested = false;
+    KBD_Mode_CancelDeepSleepCheck();
+    PFIC_EnableIRQ(RTC_IRQn);
 
     /* 清空报告缓冲区 */
     memset(g_kbd_report, 0, sizeof(g_kbd_report));
@@ -80,14 +115,18 @@ int KBD_Mode_Init(kbd_work_mode_t initial_mode, kbd_mode_callbacks_t *pCBs)
      * - BLE 模式：仅 BLE HID，不初始化 USB
      * 模式切换通过 SYS_ResetExecute() 全系统复位实现
      */
-    if (initial_mode == KBD_WORK_MODE_BLE) {
+    if (initial_mode == KBD_WORK_MODE_BLE)
+    {
         /* BLE 模式：初始化 BLE HID，广播由 GAPROLE_STARTED 回调自动触发 */
         ret = BLE_HID_Init(&g_ble_callbacks);
-        if (ret != 0) {
+        if (ret != 0)
+        {
             LOG_E(TAG, "BLE init failed %d", ret);
             return ret;
         }
-    } else {
+    }
+    else
+    {
         /* USB 模式：仅初始化 USB */
         USB_Device_Init();
     }
@@ -98,16 +137,73 @@ int KBD_Mode_Init(kbd_work_mode_t initial_mode, kbd_mode_callbacks_t *pCBs)
 void KBD_Mode_Process(void)
 {
     /* USB 模式：轮询枚举状态，枚举完成后才置 CONNECTED */
-    if (g_current_mode == KBD_WORK_MODE_USB) {
+    if (g_current_mode == KBD_WORK_MODE_USB)
+    {
         bool usb_configured = (g_USB_DeviceState == USB_STATE_CONFIGURED);
-        bool is_connected   = (g_conn_state == KBD_CONN_CONNECTED);
+        bool is_connected = (g_conn_state == KBD_CONN_CONNECTED);
 
-        if (usb_configured && !is_connected) {
+        if (usb_configured && !is_connected)
+        {
             KBD_Mode_UpdateConnState(KBD_CONN_CONNECTED);
-        } else if (!usb_configured && is_connected) {
+        }
+        else if (!usb_configured && is_connected)
+        {
             KBD_Mode_UpdateConnState(KBD_CONN_DISCONNECTED);
         }
     }
+
+    if (g_pm_state == KBD_PM_LIGHT)
+    {
+        /*
+         * LIGHT 期间由我们主动执行 CPU idle。
+         * 这里不能依赖 BLE idleCB 自动 Sleep，否则会在 RGB 活跃期打断 TMR1/DMA，
+         * 导致 WS2812 上电阶段闪烁。
+         */
+        if (g_wake_requested || !KBD_Mode_CanEnterLowPower())
+        {
+            KBD_Mode_ExitLightSleep();
+            return;
+        }
+
+        if (KBD_Mode_CanEnterDeepSleep() &&
+            KBD_Mode_GetIdleMs() >= KBD_DEEP_SLEEP_TIMEOUT_MS)
+        {
+            KBD_Mode_EnterDeepSleep();
+            /* 不返回（Shutdown 后唤醒等价复位） */
+        }
+
+        if (KBD_Mode_IsDeepSleepCheckDue() && KBD_Mode_CanEnterDeepSleep())
+        {
+            KBD_Mode_EnterDeepSleep();
+        }
+
+        LowPower_Idle();
+        return;
+    }
+
+    /* ACTIVE */
+    if (KBD_Mode_CanEnterLowPower() &&
+        KBD_Mode_GetIdleMs() >= KBD_LIGHT_SLEEP_TIMEOUT_MS)
+    {
+        KBD_Mode_EnterLightSleep();
+        return;
+    }
+
+    KBD_Mode_RefreshIndicatorState();
+}
+
+void KBD_Mode_RecordActivity(void)
+{
+    KBD_Mode_RecordActivityInternal();
+    if (g_pm_state != KBD_PM_ACTIVE)
+    {
+        KBD_Mode_RequestWake();
+    }
+}
+
+void KBD_Mode_RequestWake(void)
+{
+    g_wake_requested = true;
 }
 
 /*============================================================================*/
@@ -116,11 +212,13 @@ void KBD_Mode_Process(void)
 
 int KBD_Mode_Switch(kbd_work_mode_t mode)
 {
-    if (g_mode_switching) {
+    if (g_mode_switching)
+    {
         return -1;
     }
 
-    if (mode == g_current_mode) {
+    if (mode == g_current_mode)
+    {
         return 0;
     }
 
@@ -151,8 +249,7 @@ kbd_work_mode_t KBD_Mode_Get(void)
 
 int KBD_Mode_Toggle(void)
 {
-    kbd_work_mode_t new_mode = (g_current_mode == KBD_WORK_MODE_USB) ?
-                               KBD_WORK_MODE_BLE : KBD_WORK_MODE_USB;
+    kbd_work_mode_t new_mode = (g_current_mode == KBD_WORK_MODE_USB) ? KBD_WORK_MODE_BLE : KBD_WORK_MODE_USB;
     return KBD_Mode_Switch(new_mode);
 }
 
@@ -172,14 +269,22 @@ bool KBD_Mode_IsConnected(void)
 
 static void KBD_Mode_UpdateConnState(kbd_conn_state_t state)
 {
-    if (state == g_conn_state) {
+    if (state == g_conn_state)
+    {
         return;
     }
 
     g_conn_state = state;
+    g_last_activity_tick = KBD_Mode_GetNow();
     LOG_D(TAG, "conn state=%d", state);
 
-    if (g_pCallbacks && g_pCallbacks->onConnStateChange) {
+    if (g_pm_state == KBD_PM_LIGHT)
+    {
+        KBD_Mode_ArmDeepSleepCheck();
+    }
+
+    if (g_pCallbacks && g_pCallbacks->onConnStateChange)
+    {
         g_pCallbacks->onConnStateChange(state);
     }
 }
@@ -190,7 +295,8 @@ static void KBD_Mode_UpdateConnState(kbd_conn_state_t state)
 
 int KBD_Mode_BLE_StartAdvertising(void)
 {
-    if (g_current_mode != KBD_WORK_MODE_BLE) {
+    if (g_current_mode != KBD_WORK_MODE_BLE)
+    {
         return -1;
     }
     return BLE_HID_StartAdvertising();
@@ -210,19 +316,22 @@ int KBD_Mode_BLE_ClearBonds(void)
 {
     int ret;
 
-    if (g_mode_switching) {
+    if (g_mode_switching)
+    {
         return -1;
     }
 
     /* 非 BLE 模式下不执行任何清配对操作 */
-    if (g_current_mode != KBD_WORK_MODE_BLE) {
+    if (g_current_mode != KBD_WORK_MODE_BLE)
+    {
         return -1;
     }
 
     BLE_HID_StopAdvertising();
 
     ret = BLE_HID_ClearBonds();
-    if (ret != 0) {
+    if (ret != 0)
+    {
         KBD_Mode_UpdateConnState(KBD_CONN_DISCONNECTED);
         return ret;
     }
@@ -251,13 +360,13 @@ uint8_t KBD_Mode_BLE_GetBondCount(void)
 
 bool KBD_Mode_USB_IsPlugged(void)
 {
-    extern USB_DeviceState_t g_USB_DeviceState;
     return (g_USB_DeviceState >= USB_STATE_POWERED);
 }
 
 int KBD_Mode_USB_Wakeup(void)
 {
-    if (g_current_mode != KBD_WORK_MODE_USB) {
+    if (g_current_mode != KBD_WORK_MODE_USB)
+    {
         return -1;
     }
     USB_Device_Wakeup();
@@ -270,24 +379,31 @@ int KBD_Mode_USB_Wakeup(void)
 
 int KBD_Mode_SendKeyboardReport(uint8_t modifier, uint8_t *keys, uint8_t key_count)
 {
-    if (!KBD_Mode_IsConnected()) {
+    if (!KBD_Mode_IsConnected())
+    {
         return -1;
     }
+
+    KBD_Mode_RecordActivityInternal();
 
     /* 构建报告 */
     memset(g_kbd_report, 0, sizeof(g_kbd_report));
     g_kbd_report[0] = modifier;
-    g_kbd_report[1] = 0;  /* Reserved */
+    g_kbd_report[1] = 0; /* Reserved */
 
     uint8_t count = (key_count > 6) ? 6 : key_count;
-    if (keys && count > 0) {
+    if (keys && count > 0)
+    {
         memcpy(&g_kbd_report[2], keys, count);
     }
 
-    if (g_current_mode == KBD_WORK_MODE_USB) {
+    if (g_current_mode == KBD_WORK_MODE_USB)
+    {
         USB_Keyboard_Press(modifier, keys, key_count);
         return 0;
-    } else {
+    }
+    else
+    {
         return BLE_HID_SendKeyboardReport(modifier, keys, key_count);
     }
 }
@@ -298,7 +414,8 @@ int KBD_Mode_SendKeyPress(uint8_t modifier, uint8_t keycode)
     int ret;
 
     ret = KBD_Mode_SendKeyboardReport(modifier, keys, 1);
-    if (ret != 0) return ret;
+    if (ret != 0)
+        return ret;
 
     mDelaymS(20);
 
@@ -307,30 +424,41 @@ int KBD_Mode_SendKeyPress(uint8_t modifier, uint8_t keycode)
 
 int KBD_Mode_ReleaseAllKeys(void)
 {
-    if (g_current_mode == KBD_WORK_MODE_USB) {
+    if (g_current_mode == KBD_WORK_MODE_USB)
+    {
         USB_Keyboard_Release();
         return 0;
-    } else {
+    }
+    else
+    {
         return BLE_HID_SendKeyboardReport(0, NULL, 0);
     }
 }
 
 int KBD_Mode_SendMouseReport(uint8_t buttons, int8_t x, int8_t y, int8_t wheel)
 {
-    if (!KBD_Mode_IsConnected()) {
+    if (!KBD_Mode_IsConnected())
+    {
         return -1;
     }
 
-    if (g_current_mode == KBD_WORK_MODE_USB) {
-        if (buttons != g_mouse_report[0]) {
+    KBD_Mode_RecordActivityInternal();
+
+    if (g_current_mode == KBD_WORK_MODE_USB)
+    {
+        if (buttons != g_mouse_report[0])
+        {
             USB_Mouse_Press(buttons);
         }
-        if (x != 0 || y != 0 || wheel != 0) {
+        if (x != 0 || y != 0 || wheel != 0)
+        {
             USB_Mouse_Move(x, y, wheel);
         }
         g_mouse_report[0] = buttons;
         return 0;
-    } else {
+    }
+    else
+    {
         return BLE_HID_SendMouseReport(buttons, x, y, wheel);
     }
 }
@@ -340,7 +468,8 @@ int KBD_Mode_SendMouseClick(uint8_t buttons)
     int ret;
 
     ret = KBD_Mode_SendMouseReport(buttons, 0, 0, 0);
-    if (ret != 0) return ret;
+    if (ret != 0)
+        return ret;
 
     mDelaymS(50);
 
@@ -349,18 +478,27 @@ int KBD_Mode_SendMouseClick(uint8_t buttons)
 
 int KBD_Mode_SendConsumerReport(uint16_t key)
 {
-    if (!KBD_Mode_IsConnected()) {
+    if (!KBD_Mode_IsConnected())
+    {
         return -1;
     }
 
-    if (g_current_mode == KBD_WORK_MODE_USB) {
-        if (key != 0) {
+    KBD_Mode_RecordActivityInternal();
+
+    if (g_current_mode == KBD_WORK_MODE_USB)
+    {
+        if (key != 0)
+        {
             USB_Consumer_Press(key);
-        } else {
+        }
+        else
+        {
             USB_Consumer_Release();
         }
         return 0;
-    } else {
+    }
+    else
+    {
         return BLE_HID_SendConsumerReport(key);
     }
 }
@@ -370,7 +508,8 @@ int KBD_Mode_SendConsumerKey(uint16_t key)
     int ret;
 
     ret = KBD_Mode_SendConsumerReport(key);
-    if (ret != 0) return ret;
+    if (ret != 0)
+        return ret;
 
     mDelaymS(50);
 
@@ -383,28 +522,139 @@ int KBD_Mode_SendConsumerKey(uint16_t key)
 
 void KBD_Mode_EnterSleep(void)
 {
-    if (g_is_sleeping) return;
-
-    g_is_sleeping = true;
-    LOG_I(TAG, "enter sleep");
-
-    KBD_Mode_ReleaseAllKeys();
-    KBD_Storage_FlushRuntime();  /* 强制落盘 runtime 热数据（layer/mode），防断电丢失 */
-    /* TODO: 关闭 LED，配置唤醒源 */
+    KBD_Mode_EnterLightSleep();
 }
 
 void KBD_Mode_ExitSleep(void)
 {
-    if (!g_is_sleeping) return;
-
-    g_is_sleeping = false;
-    LOG_I(TAG, "exit sleep");
-    /* TODO: 恢复外设 */
+    KBD_Mode_ExitLightSleep();
 }
 
 bool KBD_Mode_IsInSleep(void)
 {
-    return g_is_sleeping;
+    return (g_pm_state != KBD_PM_ACTIVE);
+}
+
+kbd_pm_state_t KBD_Mode_GetPMState(void)
+{
+    return g_pm_state;
+}
+
+bool KBD_Mode_CanEnterLowPower(void)
+{
+    if (!KBD_LOW_POWER_ENABLE)
+    {
+        return false;
+    }
+
+    if (KBD_Battery_GetChargeState() == BAT_CHG_CHARGING)
+    {
+        return false;
+    }
+
+    if (KBD_Mode_USB_HasProtocolHandshake())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+/** 进入 DEEP 需要额外条件：不要让深休眠打断已有连接。 */
+static bool KBD_Mode_CanEnterDeepSleep(void)
+{
+    if (!KBD_Mode_CanEnterLowPower())
+    {
+        return false;
+    }
+
+    /* USB 线已插入（即使未枚举）时不 Shutdown，避免用户拔插跟 reset 竞争 */
+    if (KBD_Mode_USB_IsPlugged())
+    {
+        return false;
+    }
+
+    /* BLE 已连接时不 Shutdown，避免无谓的断开重连 */
+    if (g_conn_state == KBD_CONN_CONNECTED)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+static void KBD_Mode_EnterLightSleep(void)
+{
+    if (g_pm_state != KBD_PM_ACTIVE)
+        return;
+
+    if (!KBD_Mode_CanEnterLowPower())
+    {
+        LOG_I(TAG, "sleep blocked: usb_handshake=%d charging=%d",
+              KBD_Mode_USB_HasProtocolHandshake() ? 1 : 0,
+              KBD_Battery_GetChargeState() == BAT_CHG_CHARGING ? 1 : 0);
+        KBD_Mode_RefreshIndicatorState();
+        return;
+    }
+
+    KBD_Mode_PlaySleepEntryAnimation();
+
+    g_pm_state = KBD_PM_LIGHT;
+    g_wake_requested = false;
+    LOG_I(TAG, "enter LIGHT");
+
+    KBD_Mode_ReleaseAllKeys();
+    KBD_Storage_FlushRuntime(); /* 强制落盘 runtime 热数据，防断电丢失 */
+    KBD_RGB_SetSchedulerEnabled(false);
+    KBD_RGB_SetLowPower(true); /* 内部 WS2812_Sleep() 切断 LED 电源 + 数据脚高阻 */
+    KBD_Battery_Suspend();     /* 关闭 VBAT 分压 + 停止周期性采样 */
+    Key_EnterSleep();          /* 停 TMR0，保留 GPIO 中断作为按键唤醒源 */
+    KBD_Mode_ArmDeepSleepCheck();
+}
+
+static void KBD_Mode_ExitLightSleep(void)
+{
+    if (g_pm_state != KBD_PM_LIGHT)
+        return;
+
+    g_pm_state = KBD_PM_ACTIVE;
+    g_wake_requested = false;
+    LOG_I(TAG, "exit LIGHT");
+
+    KBD_Mode_CancelDeepSleepCheck();
+    Key_ExitSleep();
+    KBD_Battery_Resume();
+    KBD_RGB_SetLowPower(false);
+    KBD_RGB_SetSchedulerEnabled(true);
+
+    g_last_activity_tick = KBD_Mode_GetNow();
+    KBD_Mode_RefreshIndicatorState();
+}
+
+static void KBD_Mode_EnterDeepSleep(void)
+{
+    LOG_I(TAG, "enter DEEP (shutdown)");
+    g_pm_state = KBD_PM_DEEP;
+    KBD_Mode_CancelDeepSleepCheck();
+
+    /* BLE 主动断开 + 停广播（CanEnterDeepSleep 已排除 CONNECTED，这里是兜底） */
+    if (g_current_mode == KBD_WORK_MODE_BLE)
+    {
+        BLE_HID_StopAdvertising();
+        BLE_HID_Disconnect();
+    }
+
+    /* 持久化（Shutdown 之后 RAM 不保留） */
+    KBD_Storage_FlushRuntime();
+
+    /* 配置按键低电平作为 GPIO 唤醒源 */
+    Key_ConfigDeepSleepWakeup();
+
+    /* 确保 Flash / 日志等写操作落盘 */
+    mDelaymS(5);
+
+    LowPower_Shutdown(0);
+    /* Shutdown 唤醒 = 复位，不会返回 */
 }
 
 /*============================================================================*/
@@ -424,42 +674,182 @@ static void KBD_Mode_BLE_StateCallback(gapRole_States_t newState)
 {
     uint8_t state = (newState & GAPROLE_STATE_ADV_MASK);
 
-    if (g_mode_switching || g_current_mode != KBD_WORK_MODE_BLE) {
+    if (g_mode_switching || g_current_mode != KBD_WORK_MODE_BLE)
+    {
         return;
     }
 
-    if (state == GAPROLE_CONNECTED || state == GAPROLE_CONNECTED_ADV) {
+    if (state == GAPROLE_CONNECTED || state == GAPROLE_CONNECTED_ADV)
+    {
         LOG_I(TAG, "BLE connected");
         KBD_Storage_DeferRuntimeSave(5000); /* 推迟 Flash 写入，避免打断 BLE 配对握手 */
         KBD_Mode_UpdateConnState(KBD_CONN_CONNECTED);
         return;
     }
 
-    switch (state) {
-        case GAPROLE_STARTED:
-            LOG_D(TAG, "BLE started");
-            break;
+    switch (state)
+    {
+    case GAPROLE_STARTED:
+        LOG_D(TAG, "BLE started");
+        break;
 
-        case GAPROLE_ADVERTISING:
-            LOG_I(TAG, "BLE advertising");
-            KBD_Mode_UpdateConnState(KBD_CONN_ADVERTISING);
-            break;
+    case GAPROLE_ADVERTISING:
+        LOG_I(TAG, "BLE advertising");
+        KBD_Mode_UpdateConnState(KBD_CONN_ADVERTISING);
+        break;
 
-        case GAPROLE_WAITING:
-            LOG_I(TAG, "BLE waiting");
-            KBD_Mode_UpdateConnState(KBD_CONN_DISCONNECTED);
-            break;
+    case GAPROLE_WAITING:
+        LOG_I(TAG, "BLE waiting");
+        KBD_Mode_UpdateConnState(KBD_CONN_DISCONNECTED);
+        break;
 
-        default:
-            break;
+    default:
+        break;
     }
 }
 
 static void KBD_Mode_BLE_LedCallback(uint8_t leds)
 {
     g_keyboard_leds = leds;
+    KBD_Mode_RecordActivityInternal();
 
-    if (g_pCallbacks && g_pCallbacks->onLedReport) {
+    if (g_pCallbacks && g_pCallbacks->onLedReport)
+    {
         g_pCallbacks->onLedReport(leds);
     }
+}
+
+static uint32_t KBD_Mode_GetNow(void)
+{
+    return RTC_GetCycle32k();
+}
+
+static void KBD_Mode_RecordActivityInternal(void)
+{
+    g_last_activity_tick = KBD_Mode_GetNow();
+}
+
+static uint32_t KBD_Mode_GetIdleMs(void)
+{
+    uint32_t now = KBD_Mode_GetNow();
+    uint32_t elapsed;
+
+    if (now >= g_last_activity_tick)
+    {
+        elapsed = now - g_last_activity_tick;
+    }
+    else
+    {
+        /* RTC 32K 计数器回绕，按同一时基补足差值。 */
+        elapsed = (RTC_MAX_COUNT - g_last_activity_tick) + now;
+    }
+
+    return (uint32_t)(((uint64_t)elapsed * 1000u + (KBD_RTC_FREQ_HZ / 2u)) / KBD_RTC_FREQ_HZ);
+}
+
+static void KBD_Mode_CancelDeepSleepCheck(void)
+{
+    RTC_ModeFunDisable(RTC_TRIG_MODE);
+    RTC_ClearITFlag(RTC_TRIG_EVENT);
+    RTCTigFlag = 0;
+    PWR_PeriphWakeUpCfg(DISABLE, RB_SLP_RTC_WAKE, Long_Delay);
+}
+
+static void KBD_Mode_ArmDeepSleepCheck(void)
+{
+    uint32_t idle_ms = KBD_Mode_GetIdleMs();
+    uint32_t remain_ms = (idle_ms >= KBD_DEEP_SLEEP_TIMEOUT_MS)
+                             ? 1u
+                             : (KBD_DEEP_SLEEP_TIMEOUT_MS - idle_ms);
+    uint32_t rtc_cycles = (uint32_t)(((uint64_t)remain_ms * KBD_RTC_FREQ_HZ + 999u) / 1000u);
+
+    if (rtc_cycles == 0u)
+    {
+        rtc_cycles = 1u;
+    }
+
+    KBD_Mode_CancelDeepSleepCheck();
+    PWR_PeriphWakeUpCfg(ENABLE, RB_SLP_RTC_WAKE, Long_Delay);
+    PFIC_EnableIRQ(RTC_IRQn);
+    RTCTigFlag = 0;
+    RTC_TRIGFunCfg(rtc_cycles);
+}
+
+static bool KBD_Mode_IsDeepSleepCheckDue(void)
+{
+    if (RTCTigFlag == 0)
+    {
+        return false;
+    }
+
+    RTCTigFlag = 0;
+    RTC_ClearITFlag(RTC_TRIG_EVENT);
+    return true;
+}
+
+static bool KBD_Mode_USB_HasProtocolHandshake(void)
+{
+    return (g_USB_DeviceState >= USB_STATE_CONFIGURED);
+}
+
+static void KBD_Mode_PlaySleepEntryAnimation(void)
+{
+    for (uint8_t i = 0; i < KBD_SLEEP_ENTRY_FLASH_COUNT; i++)
+    {
+        /* 固定使用睡眠提示色，避免 BLE 断连等状态色与“将要休眠”混淆。 */
+        WS2812_FillKeys(0, 0, 0);
+        WS2812_Set_Indicator(KBD_IND_SLEEP_READY_R,
+                             KBD_IND_SLEEP_READY_G,
+                             KBD_IND_SLEEP_READY_B);
+        WS2812_Update();
+        mDelaymS(KBD_SLEEP_ENTRY_FLASH_ON_MS);
+
+        WS2812_Clear_Indicator();
+        WS2812_Update();
+
+        if ((i + 1u) < KBD_SLEEP_ENTRY_FLASH_COUNT)
+        {
+            mDelaymS(KBD_SLEEP_ENTRY_FLASH_OFF_MS);
+        }
+    }
+}
+
+static kbd_state_t KBD_Mode_ResolveIndicatorState(void)
+{
+    if (g_current_mode == KBD_WORK_MODE_USB && g_USB_DeviceState >= USB_STATE_POWERED)
+    {
+        return KBD_STATE_USB_CONNECTED;
+    }
+
+    if (KBD_Battery_GetChargeState() == BAT_CHG_CHARGING)
+    {
+        return KBD_STATE_CHARGING;
+    }
+
+    if (KBD_Battery_GetLevel() <= KBD_LOW_BATTERY_INDICATOR_LEVEL)
+    {
+        return KBD_STATE_LOW_BATTERY;
+    }
+
+    if (g_current_mode == KBD_WORK_MODE_USB)
+    {
+        return KBD_STATE_USB_CONNECTED;
+    }
+
+    switch (g_conn_state)
+    {
+    case KBD_CONN_CONNECTED:
+        return KBD_STATE_BLE_CONNECTED;
+    case KBD_CONN_ADVERTISING:
+        return KBD_STATE_BLE_ADVERTISING;
+    case KBD_CONN_SUSPENDED:
+    case KBD_CONN_DISCONNECTED:
+    default:
+        return KBD_STATE_BLE_DISCONNECTED;
+    }
+}
+
+static void KBD_Mode_RefreshIndicatorState(void)
+{
+    KBD_RGB_SetState(KBD_Mode_ResolveIndicatorState());
 }

--- a/firmware/CH592F/hal/include/kbd_battery.h
+++ b/firmware/CH592F/hal/include/kbd_battery.h
@@ -76,6 +76,16 @@ kbd_charge_state_t KBD_Battery_GetChargeState(void);
  */
 uint8_t KBD_Battery_GetVoltage_dV(void);
 
+/**
+ * @brief 进入低功耗：停止周期性采样，确保 VBAT 分压关闭
+ */
+void KBD_Battery_Suspend(void);
+
+/**
+ * @brief 退出低功耗：立即刷新一次电量并重新启动周期性采样
+ */
+void KBD_Battery_Resume(void);
+
 /** @} */
 
 #endif /* KBD_BATTERY_H */

--- a/firmware/CH592F/hal/include/kbd_config.h
+++ b/firmware/CH592F/hal/include/kbd_config.h
@@ -94,7 +94,7 @@ typedef struct
 #define KBD_INDICATOR_MIN_BRIGHTNESS 13
 
 /* TP4054 充电状态引脚: PA13 (开漏输出, 低=充电中, 高阻=未充电) */
-#define KBD_HAS_CHARGE_DET 1
+#define KBD_HAS_CHARGE_DET 0
 #define KBD_CHG_PORT GPIO_PORT_A
 #define KBD_CHG_PIN GPIO_Pin_13
 
@@ -109,13 +109,14 @@ typedef struct
  * @brief ADC 满量程电压 (mV)
  *
  * 公式: VBAT_mV = adc * KBD_VBAT_FULL_SCALE_MV / 2048
- * 默认值 4200 对应当前板级电池采样链路的实测满量程
+ * 当前板级实测仍按 4200mV 满量程标定；
+ * 若再把外部 1/2 分压额外乘回去，会直接上报约 8.4V
  *
  * 校准方法: 用万用表测实际电压 Vreal,
  *   新值 = 旧值 * Vreal / V显示
  *   例: 旧值 4200, 万用表 3.95V, 显示 4.10V → 4200 * 3.95 / 4.10 ≈ 4046
  */
-#define KBD_VBAT_FULL_SCALE_MV 4200
+#define KBD_VBAT_FULL_SCALE_MV 4200u
 
 /** @} */
 
@@ -131,6 +132,11 @@ typedef struct
 /* BOOT 按键: PB22 */
 #define KBD_FN_BOOT_PORT GPIO_PORT_B
 #define KBD_FN_BOOT_PIN GPIO_Pin_22
+
+/* 调试入口：单击 BOOT 键后直接进入 IAP bootloader */
+#ifndef KBD_BOOT_KEY_ENTER_BOOTLOADER
+#define KBD_BOOT_KEY_ENTER_BOOTLOADER 1
+#endif
 
 /* FN1: PA4 */
 #define KBD_FN1_PORT GPIO_PORT_A

--- a/firmware/CH592F/hal/include/kbd_config.h
+++ b/firmware/CH592F/hal/include/kbd_config.h
@@ -242,8 +242,10 @@ typedef struct
  */
 #if defined(KBD_LAYOUT_5KEY)
 #define KBD_LOGICAL_TO_PHYSICAL_MAP {2, 3, 4, 1, 0}
+#define KBD_LAYER_TO_KEY_MAP {0, 1, 2, 3, 4}
 #elif defined(KBD_LAYOUT_KNOB)
 #define KBD_LOGICAL_TO_PHYSICAL_MAP {3, 2, 0, 1}
+#define KBD_LAYER_TO_KEY_MAP {1, 0, 3, 2}
 #endif
 
 /**

--- a/firmware/CH592F/hal/include/key.h
+++ b/firmware/CH592F/hal/include/key.h
@@ -252,6 +252,13 @@ void Key_EnterSleep(void);
  */
 void Key_ExitSleep(void);
 
+/**
+ * @brief 配置深度休眠唤醒：所有按键引脚设置为低电平触发 + 打开 GPIO 唤醒源。
+ * @note 进入 LowPower_Shutdown() / LowPower_Sleep() 前调用；
+ *       任意按键 / FN 键按下（低电平）都会唤醒 MCU。
+ */
+void Key_ConfigDeepSleepWakeup(void);
+
 /** @} */ /* end of KBD_KEY */
 
 #ifdef __cplusplus

--- a/firmware/CH592F/hal/include/ws2812.h
+++ b/firmware/CH592F/hal/include/ws2812.h
@@ -137,4 +137,14 @@ void WS2812_Set_Indicator(uint8_t r, uint8_t g, uint8_t b);
  */
 void WS2812_Clear_Indicator(void);
 
+/**
+ * @brief 进入超低功耗：停 PWM/DMA，拉低使能脚，数据脚置高阻，切断 ESD 漏流
+ */
+void WS2812_Sleep(void);
+
+/**
+ * @brief 退出低功耗：数据脚恢复推挽输出（使能由下一次 WS2812_Update 自动打开）
+ */
+void WS2812_Wakeup(void);
+
 #endif /* __WS2812_H */

--- a/firmware/CH592F/hal/src/kbd_battery.c
+++ b/firmware/CH592F/hal/src/kbd_battery.c
@@ -55,23 +55,33 @@ static uint8_t s_sample_pending = FALSE;
  * @brief 分段线性映射 (LiPo 3.0V - 4.2V)
  * 注: 实际充电时电压通常在4.15V-4.18V即停止，故调整最后一段使其更容易达到100%
  */
-static const struct {
+static const struct
+{
   uint16_t mv;
   uint8_t pct;
 } lipo_curve[] = {
-    {3000, 0},  {3300, 5},   {3600, 20}, {3700, 40},
-    {3800, 60}, {3950, 80},  {4100, 95}, {4150, 100},
+    {3000, 0},
+    {3300, 5},
+    {3600, 20},
+    {3700, 40},
+    {3800, 60},
+    {3950, 80},
+    {4100, 95},
+    {4150, 100},
 };
 #define CURVE_LEN (sizeof(lipo_curve) / sizeof(lipo_curve[0]))
 
-static uint8_t voltage_to_percent(uint16_t mv) {
+static uint8_t voltage_to_percent(uint16_t mv)
+{
   if (mv <= lipo_curve[0].mv)
     return 0;
   if (mv >= lipo_curve[CURVE_LEN - 1].mv)
     return 100;
 
-  for (uint8_t i = 1; i < CURVE_LEN; i++) {
-    if (mv <= lipo_curve[i].mv) {
+  for (uint8_t i = 1; i < CURVE_LEN; i++)
+  {
+    if (mv <= lipo_curve[i].mv)
+    {
       uint16_t dv = lipo_curve[i].mv - lipo_curve[i - 1].mv;
       uint8_t dp = lipo_curve[i].pct - lipo_curve[i - 1].pct;
       return lipo_curve[i - 1].pct +
@@ -82,14 +92,17 @@ static uint8_t voltage_to_percent(uint16_t mv) {
 }
 
 static uint8_t battery_level_from_state(uint16_t mv,
-                                        kbd_charge_state_t charge_state) {
+                                        kbd_charge_state_t charge_state)
+{
   uint8_t level = voltage_to_percent(mv);
 
-  if (charge_state == BAT_CHG_CHARGING) {
+  if (charge_state == BAT_CHG_CHARGING)
+  {
     return (level > BAT_CHARGING_LEVEL_MAX) ? BAT_CHARGING_LEVEL_MAX : level;
   }
 
-  if (mv >= BAT_FULL_DONE_MV) {
+  if (mv >= BAT_FULL_DONE_MV)
+  {
     return 100;
   }
 
@@ -103,7 +116,8 @@ static uint16_t KBD_Battery_ProcessEvent(uint8_t task_id, uint16_t events);
 /*============================================================================*/
 
 /** 初始化外部 ADC 通道用于 VBAT 采样 */
-static void adc_vbat_init(void) {
+static void adc_vbat_init(void)
+{
   /* 外部通道初始化: 采样时钟 3.2MHz, PGA = -12dB (1/4x) */
   ADC_ExtSingleChSampInit(SampleFreq_3_2, ADC_PGA_1_4);
   /* 选择 AIN4 通道 (PA14) */
@@ -114,10 +128,12 @@ static void adc_vbat_init(void) {
  * @brief 在分压已稳定后执行多次 ADC 采样并求平均
  * @return 校准后的 ADC 值
  */
-static uint16_t adc_sample_avg(void) {
+static uint16_t adc_sample_avg(void)
+{
   uint32_t sum = 0;
 
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < 8; i++)
+  {
     sum += ADC_ExcutSingleConver();
   }
 
@@ -130,14 +146,18 @@ static uint16_t adc_sample_avg(void) {
   return (uint16_t)avg;
 }
 
-static void battery_schedule_periodic_refresh(void) {
-  if (s_task_id != TASK_NO_TASK) {
+static void battery_schedule_periodic_refresh(void)
+{
+  if (s_task_id != TASK_NO_TASK)
+  {
     tmos_start_task(s_task_id, BAT_PERIODIC_EVT, MS1_TO_SYSTEM_TIME(BAT_PERIODIC_MS));
   }
 }
 
-static void battery_start_sample(void) {
-  if (s_task_id == TASK_NO_TASK || s_sample_pending) {
+static void battery_start_sample(void)
+{
+  if (s_task_id == TASK_NO_TASK || s_sample_pending)
+  {
     return;
   }
 
@@ -148,10 +168,12 @@ static void battery_start_sample(void) {
   tmos_start_task(s_task_id, BAT_SAMPLE_EVT, MS1_TO_SYSTEM_TIME(BAT_SETTLE_MS));
 }
 
-static void battery_finish_sample(void) {
+static void battery_finish_sample(void)
+{
   uint16_t adc;
 
-  if (!s_sample_pending) {
+  if (!s_sample_pending)
+  {
     return;
   }
 
@@ -160,7 +182,8 @@ static void battery_finish_sample(void) {
   adc = adc_sample_avg();
   GPIOA_ResetBits(KBD_VBAT_EN_PIN);
 
-  s_cached_voltage_mv = (uint16_t)((uint32_t)adc * KBD_VBAT_FULL_SCALE_MV / 2048);
+  s_cached_voltage_mv =
+      (uint16_t)((uint32_t)adc * KBD_VBAT_FULL_SCALE_MV / 2048);
   s_cache_ready = TRUE;
   s_sample_pending = FALSE;
 }
@@ -169,7 +192,8 @@ static void battery_finish_sample(void) {
 /*                              公共接口                                       */
 /*============================================================================*/
 
-void KBD_Battery_Init(void) {
+void KBD_Battery_Init(void)
+{
   /* PA15: 分压使能, 推挽输出, 默认低 (关闭分压省电) */
   GPIOA_ResetBits(KBD_VBAT_EN_PIN);
   GPIOA_ModeCfg(KBD_VBAT_EN_PIN, GPIO_ModeOut_PP_5mA);
@@ -180,18 +204,22 @@ void KBD_Battery_Init(void) {
   /* 初始化 ADC 并获取校准值 */
   adc_vbat_init();
   s_adc_calib = ADC_DataCalib_Rough();
-  if (s_adc_calib > BAT_ADC_CALIB_LIMIT) {
+  if (s_adc_calib > BAT_ADC_CALIB_LIMIT)
+  {
     LOG_W(TAG, "Battery ADC calib too high: %d -> %d", s_adc_calib,
           BAT_ADC_CALIB_LIMIT);
     s_adc_calib = BAT_ADC_CALIB_LIMIT;
-  } else if (s_adc_calib < -BAT_ADC_CALIB_LIMIT) {
+  }
+  else if (s_adc_calib < -BAT_ADC_CALIB_LIMIT)
+  {
     LOG_W(TAG, "Battery ADC calib too low: %d -> %d", s_adc_calib,
           -BAT_ADC_CALIB_LIMIT);
     s_adc_calib = -BAT_ADC_CALIB_LIMIT;
   }
 
   s_task_id = TMOS_ProcessEventRegister(KBD_Battery_ProcessEvent);
-  if (s_task_id == TASK_NO_TASK) {
+  if (s_task_id == TASK_NO_TASK)
+  {
     LOG_W(TAG, "Battery TMOS task register failed");
   }
 
@@ -206,45 +234,73 @@ void KBD_Battery_Init(void) {
         s_adc_calib);
 }
 
-void KBD_Battery_RequestRefresh(void) {
+void KBD_Battery_RequestRefresh(void)
+{
   battery_start_sample();
 }
 
-uint16_t KBD_Battery_GetVoltage_mV(void) {
-  if (!s_cache_ready || !s_sample_pending) {
+uint16_t KBD_Battery_GetVoltage_mV(void)
+{
+  if (!s_cache_ready || !s_sample_pending)
+  {
     KBD_Battery_RequestRefresh();
   }
   return s_cached_voltage_mv;
 }
 
-uint8_t KBD_Battery_GetLevel(void) {
+uint8_t KBD_Battery_GetLevel(void)
+{
   uint16_t mv = KBD_Battery_GetVoltage_mV();
   return battery_level_from_state(mv, KBD_Battery_GetChargeState());
 }
 
-kbd_charge_state_t KBD_Battery_GetChargeState(void) {
+kbd_charge_state_t KBD_Battery_GetChargeState(void)
+{
 #if KBD_HAS_CHARGE_DET
   return (GPIOA_ReadPortPin(KBD_CHG_PIN) != 0) ? BAT_CHG_NONE
-                                                : BAT_CHG_CHARGING;
+                                               : BAT_CHG_CHARGING;
 #else
   return BAT_CHG_NONE;
 #endif
 }
 
-uint8_t KBD_Battery_GetVoltage_dV(void) {
+uint8_t KBD_Battery_GetVoltage_dV(void)
+{
   return (uint8_t)(KBD_Battery_GetVoltage_mV() / 100);
 }
 
-static uint16_t KBD_Battery_ProcessEvent(uint8_t task_id, uint16_t events) {
+void KBD_Battery_Suspend(void)
+{
+  if (s_task_id != TASK_NO_TASK)
+  {
+    tmos_stop_task(s_task_id, BAT_SAMPLE_EVT);
+    tmos_stop_task(s_task_id, BAT_PERIODIC_EVT);
+  }
+  /* 确保分压电阻断电，避免 ~12.5μA 持续漏流 */
+  GPIOA_ResetBits(KBD_VBAT_EN_PIN);
+  s_sample_pending = FALSE;
+}
+
+void KBD_Battery_Resume(void)
+{
+  KBD_Battery_RequestRefresh();
+  battery_schedule_periodic_refresh();
+}
+
+static uint16_t KBD_Battery_ProcessEvent(uint8_t task_id, uint16_t events)
+{
   (void)task_id;
 
-  if (events & BAT_SAMPLE_EVT) {
+  if (events & BAT_SAMPLE_EVT)
+  {
     battery_finish_sample();
     return (events ^ BAT_SAMPLE_EVT);
   }
 
-  if (events & BAT_PERIODIC_EVT) {
-    if (!s_sample_pending) {
+  if (events & BAT_PERIODIC_EVT)
+  {
+    if (!s_sample_pending)
+    {
       battery_start_sample();
     }
     battery_schedule_periodic_refresh();

--- a/firmware/CH592F/hal/src/key.c
+++ b/firmware/CH592F/hal/src/key.c
@@ -120,6 +120,7 @@
 
 #include "key.h"
 #include "kbd_config.h"
+#include "kbd_mode.h"
 #include "encoder.h"
 
 #include <string.h>
@@ -136,9 +137,9 @@
 #define STATIC_ASSERT(cond, msg) typedef char static_assert_##msg[(cond) ? 1 : -1]
 
 /** @brief 普通按键队列大小必须为 2 的幂。 */
-STATIC_ASSERT ((KEY_QUEUE_SIZE & (KEY_QUEUE_SIZE - 1)) == 0, key_queue_must_be_power_of_2);
+STATIC_ASSERT((KEY_QUEUE_SIZE & (KEY_QUEUE_SIZE - 1)) == 0, key_queue_must_be_power_of_2);
 /** @brief FN 按键队列大小必须为 2 的幂。 */
-STATIC_ASSERT ((FNKEY_QUEUE_SIZE & (FNKEY_QUEUE_SIZE - 1)) == 0, fn_queue_must_be_power_of_2);
+STATIC_ASSERT((FNKEY_QUEUE_SIZE & (FNKEY_QUEUE_SIZE - 1)) == 0, fn_queue_must_be_power_of_2);
 
 /* ============================================================================
  * Pin mapping
@@ -241,7 +242,7 @@ static volatile uint32_t s_tick_ms = 0;
  * @brief 获取当前毫秒 tick。
  * @return 自 Key_Init() 起累计的毫秒数。
  */
-static inline uint32_t GetTickMs (void) { return s_tick_ms; }
+static inline uint32_t GetTickMs(void) { return s_tick_ms; }
 
 /* ============================================================================
  * Contexts
@@ -251,10 +252,11 @@ static inline uint32_t GetTickMs (void) { return s_tick_ms; }
 /**
  * @brief 普通按键上下文（边沿 + 锁定去抖）。
  */
-typedef struct {
+typedef struct
+{
     volatile uint16_t lock_ms; /**< 锁定倒计时（ms）。>0 表示锁定中。 */
-    volatile uint8_t  is_down; /**< 当前是否按下（1=按下，0=松开）。 */
-    volatile uint8_t  expect;  /**< 期待的边沿：0=按下(下降沿)，1=松开(上升沿)。 */
+    volatile uint8_t is_down;  /**< 当前是否按下（1=按下，0=松开）。 */
+    volatile uint8_t expect;   /**< 期待的边沿：0=按下(下降沿)，1=松开(上升沿)。 */
 } key_ctx_t;
 
 /** @brief 普通按键上下文数组（每个键一个 ctx）。 */
@@ -265,12 +267,13 @@ static volatile key_ctx_t s_key_ctx[KBD_SCAN_KEY_COUNT];
  * @details
  * FN 键在松开边沿计算 dur = now - press_tick 并决定 CLICK / LONG。
  */
-typedef struct {
-    volatile uint16_t lock_ms;     /**< 锁定倒计时（ms）。 */
-    volatile uint8_t  is_down;     /**< 当前是否按下（1=按下，0=松开）。 */
-    volatile uint8_t  expect;      /**< 期待边沿：0=按下(下降沿)，1=松开(上升沿)。 */
-    volatile uint8_t  combo_used;  /**< FN+Key 组合已触发，松开时跳过事件。 */
-    volatile uint32_t press_tick;  /**< 按下边沿发生时的 tick（ms）。 */
+typedef struct
+{
+    volatile uint16_t lock_ms;    /**< 锁定倒计时（ms）。 */
+    volatile uint8_t is_down;     /**< 当前是否按下（1=按下，0=松开）。 */
+    volatile uint8_t expect;      /**< 期待边沿：0=按下(下降沿)，1=松开(上升沿)。 */
+    volatile uint8_t combo_used;  /**< FN+Key 组合已触发，松开时跳过事件。 */
+    volatile uint32_t press_tick; /**< 按下边沿发生时的 tick（ms）。 */
 } fn_ctx_t;
 
 /** @brief FN 按键上下文数组。 */
@@ -285,33 +288,36 @@ static volatile fn_ctx_t s_fn_ctx[KBD_FN_NUM_KEYS];
  * @brief 将指定引脚配置为上拉输入。
  * @param pin 引脚描述（端口 + pin 位）。
  */
-static inline void ConfigPinInputPullup (const kbd_key_pin_t *pin) {
+static inline void ConfigPinInputPullup(const kbd_key_pin_t *pin)
+{
     if (pin->port == GPIO_PORT_A)
-        GPIOA_ModeCfg (pin->pin, GPIO_ModeIN_PU);
+        GPIOA_ModeCfg(pin->pin, GPIO_ModeIN_PU);
     else
-        GPIOB_ModeCfg (pin->pin, GPIO_ModeIN_PU);
+        GPIOB_ModeCfg(pin->pin, GPIO_ModeIN_PU);
 }
 
 /**
  * @brief 将指定引脚配置为下降沿触发中断（按下沿，Active-Low）。
  * @param pin 引脚描述。
  */
-static inline void ConfigPinFallEdge (const kbd_key_pin_t *pin) {
+static inline void ConfigPinFallEdge(const kbd_key_pin_t *pin)
+{
     if (pin->port == GPIO_PORT_A)
-        GPIOA_ITModeCfg (pin->pin, GPIO_ITMode_FallEdge);
+        GPIOA_ITModeCfg(pin->pin, GPIO_ITMode_FallEdge);
     else
-        GPIOB_ITModeCfg (pin->pin, GPIO_ITMode_FallEdge);
+        GPIOB_ITModeCfg(pin->pin, GPIO_ITMode_FallEdge);
 }
 
 /**
  * @brief 将指定引脚配置为上升沿触发中断（松开沿）。
  * @param pin 引脚描述。
  */
-static inline void ConfigPinRiseEdge (const kbd_key_pin_t *pin) {
+static inline void ConfigPinRiseEdge(const kbd_key_pin_t *pin)
+{
     if (pin->port == GPIO_PORT_A)
-        GPIOA_ITModeCfg (pin->pin, GPIO_ITMode_RiseEdge);
+        GPIOA_ITModeCfg(pin->pin, GPIO_ITMode_RiseEdge);
     else
-        GPIOB_ITModeCfg (pin->pin, GPIO_ITMode_RiseEdge);
+        GPIOB_ITModeCfg(pin->pin, GPIO_ITMode_RiseEdge);
 }
 
 /**
@@ -319,7 +325,8 @@ static inline void ConfigPinRiseEdge (const kbd_key_pin_t *pin) {
  * @param port GPIO_PORT_A / GPIO_PORT_B
  * @return 对应端口的中断标志位集合。
  */
-static inline uint32_t ReadPortItFlags (gpio_port_t port) {
+static inline uint32_t ReadPortItFlags(gpio_port_t port)
+{
     return (port == GPIO_PORT_A) ? GPIOA_ReadITFlagPort() : GPIOB_ReadITFlagPort();
 }
 
@@ -328,11 +335,12 @@ static inline uint32_t ReadPortItFlags (gpio_port_t port) {
  * @param port 端口
  * @param pin  引脚位（bitmask）
  */
-static inline void ClearPinItFlag (gpio_port_t port, uint32_t pin) {
+static inline void ClearPinItFlag(gpio_port_t port, uint32_t pin)
+{
     if (port == GPIO_PORT_A)
-        GPIOA_ClearITFlagBit (pin);
+        GPIOA_ClearITFlagBit(pin);
     else
-        GPIOB_ClearITFlagBit (pin);
+        GPIOB_ClearITFlagBit(pin);
 }
 
 /**
@@ -340,7 +348,8 @@ static inline void ClearPinItFlag (gpio_port_t port, uint32_t pin) {
  * @param port 端口
  * @param pin  引脚位（bitmask）
  */
-static inline void EnablePinIrq (gpio_port_t port, uint32_t pin) {
+static inline void EnablePinIrq(gpio_port_t port, uint32_t pin)
+{
     if (port == GPIO_PORT_A)
         R16_PA_INT_EN |= (uint16_t)pin;
     else
@@ -352,7 +361,8 @@ static inline void EnablePinIrq (gpio_port_t port, uint32_t pin) {
  * @param port 端口
  * @param pin  引脚位（bitmask）
  */
-static inline void DisablePinIrq (gpio_port_t port, uint32_t pin) {
+static inline void DisablePinIrq(gpio_port_t port, uint32_t pin)
+{
     if (port == GPIO_PORT_A)
         R16_PA_INT_EN &= (uint16_t)(~pin);
     else
@@ -365,10 +375,11 @@ static inline void DisablePinIrq (gpio_port_t port, uint32_t pin) {
  * @return 1 表示高电平（松开），0 表示低电平（按下）。
  * @note Active-Low 语义：pressed=0, released=1
  */
-static inline uint8_t ReadPinLevel(const kbd_key_pin_t *pin) {
-  uint32_t v = (pin->port == GPIO_PORT_A) ? GPIOA_ReadPortPin(pin->pin)
-                                         : GPIOB_ReadPortPin(pin->pin);
-  return (v != 0) ? 1 : 0;   /* 或 return !!v; */
+static inline uint8_t ReadPinLevel(const kbd_key_pin_t *pin)
+{
+    uint32_t v = (pin->port == GPIO_PORT_A) ? GPIOA_ReadPortPin(pin->pin)
+                                            : GPIOB_ReadPortPin(pin->pin);
+    return (v != 0) ? 1 : 0; /* 或 return !!v; */
 }
 
 /* ============================================================================
@@ -383,7 +394,8 @@ static inline uint8_t ReadPinLevel(const kbd_key_pin_t *pin) {
  * @param tick_ms 时间戳
  * @note 队列满时丢弃新事件（不覆盖旧事件）。
  */
-static inline void PushKeyEvent (uint8_t key, uint8_t type, uint32_t tick_ms) {
+static inline void PushKeyEvent(uint8_t key, uint8_t type, uint32_t tick_ms)
+{
     uint8_t next = (uint8_t)((s_key_wr + 1) & (KEY_QUEUE_SIZE - 1));
     if (next == s_key_rd)
         return;
@@ -400,7 +412,8 @@ static inline void PushKeyEvent (uint8_t key, uint8_t type, uint32_t tick_ms) {
  * @param tick_ms 时间戳
  * @note 队列满时丢弃新事件。
  */
-static inline void PushFnEvent (uint8_t id, uint8_t type, uint32_t tick_ms) {
+static inline void PushFnEvent(uint8_t id, uint8_t type, uint32_t tick_ms)
+{
     uint8_t next = (uint8_t)((s_fn_wr + 1) & (FNKEY_QUEUE_SIZE - 1));
     if (next == s_fn_rd)
         return;
@@ -427,14 +440,15 @@ static volatile uint8_t s_timer_active = 0;
  * - 提供 s_tick_ms 时间戳
  * - 驱动 key/fn 的 lock_ms 倒计时并在归零时重新使能引脚中断
  */
-static inline void StartTimer1ms (void) {
+static inline void StartTimer1ms(void)
+{
     if (s_timer_active)
         return;
 
-    TMR0_TimerInit (FREQ_SYS / 1000); /* 1ms */
-    TMR0_ITCfg (ENABLE, TMR0_3_IT_CYC_END);
-    PFIC_SetPriority (TMR0_IRQn, TIMER_IRQ_PRIORITY);
-    PFIC_EnableIRQ (TMR0_IRQn);
+    TMR0_TimerInit(FREQ_SYS / 1000); /* 1ms */
+    TMR0_ITCfg(ENABLE, TMR0_3_IT_CYC_END);
+    PFIC_SetPriority(TMR0_IRQn, TIMER_IRQ_PRIORITY);
+    PFIC_EnableIRQ(TMR0_IRQn);
 
     s_timer_active = 1;
 }
@@ -442,10 +456,11 @@ static inline void StartTimer1ms (void) {
 /**
  * @brief 停止 1ms 定时器（TMR0）。
  */
-static inline void StopTimer1ms (void) {
-    TMR0_ITCfg (DISABLE, TMR0_3_IT_CYC_END);
-    PFIC_DisableIRQ (TMR0_IRQn);
-    TMR0_ClearITFlag (TMR0_3_IT_CYC_END);
+static inline void StopTimer1ms(void)
+{
+    TMR0_ITCfg(DISABLE, TMR0_3_IT_CYC_END);
+    PFIC_DisableIRQ(TMR0_IRQn);
+    TMR0_ClearITFlag(TMR0_3_IT_CYC_END);
     s_timer_active = 0;
 }
 
@@ -465,7 +480,8 @@ static inline void StopTimer1ms (void) {
  *     - lock_ms = KEY_LOCKOUT_MS
  *     - DisablePinIrq()（锁定期间不再响应该引脚中断）
  */
-static inline void HandleNormalKeyEdge (uint8_t idx) {
+static inline void HandleNormalKeyEdge(uint8_t idx)
+{
     const kbd_key_pin_t *pin = &g_key_pins[idx];
     uint8_t logical_key = g_key_logical_ids[idx];
     if (s_key_ctx[idx].lock_ms > 0)
@@ -473,25 +489,28 @@ static inline void HandleNormalKeyEdge (uint8_t idx) {
 
     uint32_t now = GetTickMs();
 
-    if (s_key_ctx[idx].expect == 0) {
+    if (s_key_ctx[idx].expect == 0)
+    {
         s_key_ctx[idx].is_down = 1;
-        PushKeyEvent (logical_key, KEY_EVT_PRESS, now);
+        PushKeyEvent(logical_key, KEY_EVT_PRESS, now);
 
 #if KEY_ENABLE_RELEASE_EVENT
         s_key_ctx[idx].expect = 1;
-        ConfigPinRiseEdge (pin);
+        ConfigPinRiseEdge(pin);
 #else
-        ConfigPinFallEdge (pin);
+        ConfigPinFallEdge(pin);
 #endif
-    } else {
+    }
+    else
+    {
         s_key_ctx[idx].is_down = 0;
-        PushKeyEvent (logical_key, KEY_EVT_RELEASE, now);
+        PushKeyEvent(logical_key, KEY_EVT_RELEASE, now);
         s_key_ctx[idx].expect = 0;
-        ConfigPinFallEdge (pin);
+        ConfigPinFallEdge(pin);
     }
 
     s_key_ctx[idx].lock_ms = KEY_LOCKOUT_MS;
-    DisablePinIrq (pin->port, pin->pin);
+    DisablePinIrq(pin->port, pin->pin);
 }
 
 /**
@@ -502,40 +521,48 @@ static inline void HandleNormalKeyEdge (uint8_t idx) {
  * - 松开沿：dur=now-press_tick，dur>=FN_LONG_PRESS_MS -> LONG，否则 CLICK
  * - 每次边沿后都进入 lockout：禁用引脚中断，等待 1ms 定时器解锁
  */
-static inline void HandleFnKeyEdge (uint8_t id) {
+static inline void HandleFnKeyEdge(uint8_t id)
+{
     const kbd_key_pin_t *pin = &g_fn_pins[id];
     if (s_fn_ctx[id].lock_ms > 0)
         return;
 
     uint32_t now = GetTickMs();
 
-    if (s_fn_ctx[id].expect == 0) {
+    if (s_fn_ctx[id].expect == 0)
+    {
         /* Press edge. */
         s_fn_ctx[id].is_down = 1;
         s_fn_ctx[id].combo_used = 0;
         s_fn_ctx[id].press_tick = now;
         s_fn_ctx[id].expect = 1;
-        ConfigPinRiseEdge (pin);
-    } else {
+        ConfigPinRiseEdge(pin);
+    }
+    else
+    {
         /* Release edge -> decide click/long. */
         s_fn_ctx[id].is_down = 0;
         s_fn_ctx[id].expect = 0;
-        ConfigPinFallEdge (pin);
+        ConfigPinFallEdge(pin);
 
         /* FN+Key 组合已使用过，跳过 click/long 事件 */
-        if (!s_fn_ctx[id].combo_used) {
+        if (!s_fn_ctx[id].combo_used)
+        {
             uint32_t dur = now - s_fn_ctx[id].press_tick;
-            if (dur >= (uint32_t)FN_LONG_PRESS_MS) {
-                PushFnEvent (id, FNKEY_EVT_LONG, now);
-            } else {
-                PushFnEvent (id, FNKEY_EVT_CLICK, now);
+            if (dur >= (uint32_t)FN_LONG_PRESS_MS)
+            {
+                PushFnEvent(id, FNKEY_EVT_LONG, now);
+            }
+            else
+            {
+                PushFnEvent(id, FNKEY_EVT_CLICK, now);
             }
         }
         s_fn_ctx[id].combo_used = 0;
     }
 
     s_fn_ctx[id].lock_ms = FN_LOCKOUT_MS;
-    DisablePinIrq (pin->port, pin->pin);
+    DisablePinIrq(pin->port, pin->pin);
 }
 
 /* ============================================================================
@@ -554,32 +581,42 @@ static inline void HandleFnKeyEdge (uint8_t id) {
  *    - ClearPinItFlag()
  *    - 调用对应 HandleXxxEdge()
  */
-static inline void HandlePortIrq (gpio_port_t port) {
-    uint32_t flags = ReadPortItFlags (port);
+static inline void HandlePortIrq(gpio_port_t port)
+{
+    uint32_t flags = ReadPortItFlags(port);
     uint16_t enabled = (port == GPIO_PORT_A) ? R16_PA_INT_EN : R16_PB_INT_EN;
     flags &= enabled;
     if (flags == 0)
         return;
 
-    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT && flags; i++) {
+    if (KBD_Mode_IsInSleep())
+    {
+        KBD_Mode_RequestWake();
+    }
+
+    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT && flags; i++)
+    {
         if (g_key_pins[i].port != port)
             continue;
         uint32_t pin = g_key_pins[i].pin;
-        if (flags & pin) {
-            ClearPinItFlag (port, pin);
+        if (flags & pin)
+        {
+            ClearPinItFlag(port, pin);
             flags &= ~pin;
-            HandleNormalKeyEdge (i);
+            HandleNormalKeyEdge(i);
         }
     }
 
-    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS && flags; id++) {
+    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS && flags; id++)
+    {
         if (g_fn_pins[id].port != port)
             continue;
         uint32_t pin = g_fn_pins[id].pin;
-        if (flags & pin) {
-            ClearPinItFlag (port, pin);
+        if (flags & pin)
+        {
+            ClearPinItFlag(port, pin);
             flags &= ~pin;
-            HandleFnKeyEdge (id);
+            HandleFnKeyEdge(id);
         }
     }
 
@@ -589,12 +626,12 @@ static inline void HandlePortIrq (gpio_port_t port) {
 /**
  * @brief GPIOA 端口中断服务函数。
  */
-__INTERRUPT __HIGH_CODE void GPIOA_IRQHandler (void) { HandlePortIrq (GPIO_PORT_A); }
+__INTERRUPT __HIGH_CODE void GPIOA_IRQHandler(void) { HandlePortIrq(GPIO_PORT_A); }
 
 /**
  * @brief GPIOB 端口中断服务函数。
  */
-__INTERRUPT __HIGH_CODE void GPIOB_IRQHandler (void) { HandlePortIrq (GPIO_PORT_B); }
+__INTERRUPT __HIGH_CODE void GPIOB_IRQHandler(void) { HandlePortIrq(GPIO_PORT_B); }
 
 /* ============================================================================
  * TMR0 IRQ: tick + unlock
@@ -609,38 +646,43 @@ __INTERRUPT __HIGH_CODE void GPIOB_IRQHandler (void) { HandlePortIrq (GPIO_PORT_
  *   - 遍历所有普通键 ctx：若 lock_ms>0 则 lock_ms--，到 0 时清 flag 并 EnablePinIrq()
  *   - 遍历所有 FN 键 ctx：同理
  */
-__INTERRUPT __HIGH_CODE void TMR0_IRQHandler (void) {
-    if (!TMR0_GetITFlag (TMR0_3_IT_CYC_END))
+__INTERRUPT __HIGH_CODE void TMR0_IRQHandler(void)
+{
+    if (!TMR0_GetITFlag(TMR0_3_IT_CYC_END))
         return;
-    TMR0_ClearITFlag (TMR0_3_IT_CYC_END);
+    TMR0_ClearITFlag(TMR0_3_IT_CYC_END);
 
     s_tick_ms++;
 
-    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++) {
+    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++)
+    {
         uint16_t lm = s_key_ctx[i].lock_ms;
         if (lm == 0)
             continue;
         lm--;
         s_key_ctx[i].lock_ms = lm;
-        if (lm == 0) {
+        if (lm == 0)
+        {
             gpio_port_t port = g_key_pins[i].port;
             uint32_t pin = g_key_pins[i].pin;
-            ClearPinItFlag (port, pin);
-            EnablePinIrq (port, pin);
+            ClearPinItFlag(port, pin);
+            EnablePinIrq(port, pin);
         }
     }
 
-    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS; id++) {
+    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS; id++)
+    {
         uint16_t lm = s_fn_ctx[id].lock_ms;
         if (lm == 0)
             continue;
         lm--;
         s_fn_ctx[id].lock_ms = lm;
-        if (lm == 0) {
+        if (lm == 0)
+        {
             gpio_port_t port = g_fn_pins[id].port;
             uint32_t pin = g_fn_pins[id].pin;
-            ClearPinItFlag (port, pin);
-            EnablePinIrq (port, pin);
+            ClearPinItFlag(port, pin);
+            EnablePinIrq(port, pin);
         }
     }
 
@@ -657,7 +699,8 @@ __INTERRUPT __HIGH_CODE void TMR0_IRQHandler (void) {
  * @param[out] evt 事件输出
  * @return 1=成功；0=无事件或参数无效
  */
-uint8_t Key_GetEvent (key_event_t *evt) {
+uint8_t Key_GetEvent(key_event_t *evt)
+{
     if (evt == NULL)
         return 0;
     if (s_key_rd == s_key_wr)
@@ -672,7 +715,8 @@ uint8_t Key_GetEvent (key_event_t *evt) {
  * @param[out] evt 事件输出
  * @return 1=成功；0=无事件或参数无效
  */
-uint8_t FnKey_GetEvent (fnkey_event_t *evt) {
+uint8_t FnKey_GetEvent(fnkey_event_t *evt)
+{
     if (evt == NULL)
         return 0;
     if (s_fn_rd == s_fn_wr)
@@ -687,9 +731,12 @@ uint8_t FnKey_GetEvent (fnkey_event_t *evt) {
  * @param key_index 按键索引
  * @return 1=按下；0=松开；-1=非法索引
  */
-int8_t Key_IsDown (uint8_t key_index) {
-    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++) {
-        if (g_key_logical_ids[i] == key_index) {
+int8_t Key_IsDown(uint8_t key_index)
+{
+    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++)
+    {
+        if (g_key_logical_ids[i] == key_index)
+        {
             return s_key_ctx[i].is_down ? 1 : 0;
         }
     }
@@ -701,7 +748,8 @@ int8_t Key_IsDown (uint8_t key_index) {
  * @param id FN 键索引
  * @return 1=按下；0=松开；-1=非法索引
  */
-int8_t FnKey_IsDown (uint8_t id) {
+int8_t FnKey_IsDown(uint8_t id)
+{
     if (id >= KBD_FN_NUM_KEYS)
         return -1;
     return s_fn_ctx[id].is_down ? 1 : 0;
@@ -712,7 +760,8 @@ int8_t FnKey_IsDown (uint8_t id) {
  * @param id FN 键索引
  * @details 调用后，该 FN 键松开时不会产生 CLICK/LONG 事件。
  */
-void FnKey_MarkComboUsed (uint8_t id) {
+void FnKey_MarkComboUsed(uint8_t id)
+{
     if (id < KBD_FN_NUM_KEYS)
         s_fn_ctx[id].combo_used = 1;
 }
@@ -721,81 +770,104 @@ void FnKey_MarkComboUsed (uint8_t id) {
  * @brief BOOT 键是否按下（原始读取，Active-Low）。
  * @return 1=按下；0=松开
  */
-int8_t BootKey_IsPressed (void) {
+int8_t BootKey_IsPressed(void)
+{
     /* Active-low raw read. */
-    return (ReadPinLevel (&g_boot_pin) == 0) ? 1 : 0;
+    return (ReadPinLevel(&g_boot_pin) == 0) ? 1 : 0;
 }
 
 /**
  * @brief 初始化按键驱动（见 key.h 文档）。
  */
-void Key_Init (void) {
-    memset ((void *)s_key_ctx, 0, sizeof (s_key_ctx));
-    memset ((void *)s_fn_ctx, 0, sizeof (s_fn_ctx));
+void Key_Init(void)
+{
+    memset((void *)s_key_ctx, 0, sizeof(s_key_ctx));
+    memset((void *)s_fn_ctx, 0, sizeof(s_fn_ctx));
 
     s_key_rd = s_key_wr = 0;
     s_fn_rd = s_fn_wr = 0;
     s_tick_ms = 0;
 
     /* BOOT: input only. */
-    ConfigPinInputPullup (&g_boot_pin);
+    ConfigPinInputPullup(&g_boot_pin);
 
     /* Normal keys: input + falling/rising edge depends on current level. */
-    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++) {
+    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++)
+    {
         const kbd_key_pin_t *pin = &g_key_pins[i];
-        ConfigPinInputPullup (pin);
+        ConfigPinInputPullup(pin);
 
-        uint8_t level = ReadPinLevel (pin);
+        uint8_t level = ReadPinLevel(pin);
         s_key_ctx[i].is_down = (level == 0) ? 1 : 0;
         s_key_ctx[i].lock_ms = 0;
 
         /* 若初始化时已按下(level=0)，下一次应期待 release(上升沿)；否则期待 press(下降沿) */
         s_key_ctx[i].expect = (level == 0) ? 1 : 0;
         if (level == 0)
-            ConfigPinRiseEdge (pin);
+            ConfigPinRiseEdge(pin);
         else
-            ConfigPinFallEdge (pin);
+            ConfigPinFallEdge(pin);
 
-        ClearPinItFlag (pin->port, pin->pin);
-        EnablePinIrq (pin->port, pin->pin);
+        ClearPinItFlag(pin->port, pin->pin);
+        EnablePinIrq(pin->port, pin->pin);
     }
 
     /* FN keys: input + ALWAYS start from press(fall). */
-    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS; id++) {
+    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS; id++)
+    {
         const kbd_key_pin_t *pin = &g_fn_pins[id];
-        ConfigPinInputPullup (pin);
+        ConfigPinInputPullup(pin);
 
         /* 可选：读两次/丢一次，等上拉稳定 */
-        (void)ReadPinLevel (pin);
-        uint8_t level = ReadPinLevel (pin);
+        (void)ReadPinLevel(pin);
+        uint8_t level = ReadPinLevel(pin);
 
         s_fn_ctx[id].is_down = (level == 0) ? 1 : 0;
         s_fn_ctx[id].lock_ms = 0;
 
         /* 关键：强制下一次当成“按下沿” */
         s_fn_ctx[id].expect = 0;
-        s_fn_ctx[id].press_tick = 0;  /* 按下沿会重写 */
+        s_fn_ctx[id].press_tick = 0; /* 按下沿会重写 */
 
         /* 关键：强制先等下降沿（按下） */
-        ConfigPinFallEdge (pin);
+        ConfigPinFallEdge(pin);
 
-        ClearPinItFlag (pin->port, pin->pin);
-        EnablePinIrq (pin->port, pin->pin);
+        ClearPinItFlag(pin->port, pin->pin);
+        EnablePinIrq(pin->port, pin->pin);
     }
 
-    PFIC_SetPriority (GPIO_A_IRQn, KEY_IRQ_PRIORITY);
-    PFIC_SetPriority (GPIO_B_IRQn, KEY_IRQ_PRIORITY);
-    PFIC_EnableIRQ (GPIO_A_IRQn);
-    PFIC_EnableIRQ (GPIO_B_IRQn);
+    PFIC_SetPriority(GPIO_A_IRQn, KEY_IRQ_PRIORITY);
+    PFIC_SetPriority(GPIO_B_IRQn, KEY_IRQ_PRIORITY);
+    PFIC_EnableIRQ(GPIO_A_IRQn);
+    PFIC_EnableIRQ(GPIO_B_IRQn);
 
     StartTimer1ms();
 }
 
 /**
- * @brief 进入低功耗：停止 1ms 定时器。
+ * @brief 进入低功耗：停止 1ms 定时器，解除所有 lockout 并重新使能引脚 IRQ。
+ * @note 1ms 定时器停止后 lock_ms 无法递减，若不强制解锁会导致处于锁定中的键无法唤醒系统。
+ *       30s+ 空闲进入休眠时硬件上不存在抖动，可安全强制解锁。
  */
-void Key_EnterSleep (void) {
+void Key_EnterSleep(void)
+{
     Encoder_EnterSleep();
+
+    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++)
+    {
+        const kbd_key_pin_t *pin = &g_key_pins[i];
+        s_key_ctx[i].lock_ms = 0;
+        ClearPinItFlag(pin->port, pin->pin);
+        EnablePinIrq(pin->port, pin->pin);
+    }
+    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS; id++)
+    {
+        const kbd_key_pin_t *pin = &g_fn_pins[id];
+        s_fn_ctx[id].lock_ms = 0;
+        ClearPinItFlag(pin->port, pin->pin);
+        EnablePinIrq(pin->port, pin->pin);
+    }
+
     if (s_timer_active)
         StopTimer1ms();
 }
@@ -803,8 +875,40 @@ void Key_EnterSleep (void) {
 /**
  * @brief 退出低功耗：启动 1ms 定时器。
  */
-void Key_ExitSleep (void) {
+void Key_ExitSleep(void)
+{
     Encoder_ExitSleep();
     if (!s_timer_active)
         StartTimer1ms();
+}
+
+/**
+ * @brief 配置深度休眠唤醒：所有按键引脚切换到低电平触发 + 打开 GPIO 唤醒源。
+ * @note 调用前应保证按键已松开（否则进入休眠瞬间立即唤醒）。
+ *       深休眠使用 LowPower_Shutdown() 时，唤醒等价于复位，事件状态不会保留。
+ */
+void Key_ConfigDeepSleepWakeup(void)
+{
+    for (uint8_t i = 0; i < KBD_SCAN_KEY_COUNT; i++)
+    {
+        const kbd_key_pin_t *pin = &g_key_pins[i];
+        if (pin->port == GPIO_PORT_A)
+            GPIOA_ITModeCfg(pin->pin, GPIO_ITMode_LowLevel);
+        else
+            GPIOB_ITModeCfg(pin->pin, GPIO_ITMode_LowLevel);
+        ClearPinItFlag(pin->port, pin->pin);
+        EnablePinIrq(pin->port, pin->pin);
+    }
+    for (uint8_t id = 0; id < KBD_FN_NUM_KEYS; id++)
+    {
+        const kbd_key_pin_t *pin = &g_fn_pins[id];
+        if (pin->port == GPIO_PORT_A)
+            GPIOA_ITModeCfg(pin->pin, GPIO_ITMode_LowLevel);
+        else
+            GPIOB_ITModeCfg(pin->pin, GPIO_ITMode_LowLevel);
+        ClearPinItFlag(pin->port, pin->pin);
+        EnablePinIrq(pin->port, pin->pin);
+    }
+
+    PWR_PeriphWakeUpCfg(ENABLE, RB_SLP_GPIO_WAKE, Long_Delay);
 }

--- a/firmware/CH592F/hal/src/ws2812.c
+++ b/firmware/CH592F/hal/src/ws2812.c
@@ -344,3 +344,30 @@ void WS2812_Set_Indicator(uint8_t r, uint8_t g, uint8_t b) {
  * @brief 清除指示灯
  */
 void WS2812_Clear_Indicator(void) { WS2812_Set(0, 0, 0, 0); }
+
+/**
+ * @brief 进入超低功耗
+ * @note  停 PWM/DMA，拉低使能脚切断 LED 供电；数据脚置高阻，
+ *        避免 MCU 还在驱动已掉电的 LED 导致的 ESD 二极管漏流。
+ */
+void WS2812_Sleep(void) {
+  TMR1_Disable();
+  TMR1_PWMDisable();
+  TMR1_DMACfg(DISABLE, 0, 0, Mode_Single);
+
+  WS2812_DisablePower();
+  s_rgb_powered = 0;
+
+  /* 数据线置高阻：LED 掉电后仍维持推挽输出会通过 DIN ESD 二极管漏流 */
+  GPIOA_ModeCfg(WS2812_PIN, GPIO_ModeIN_Floating);
+
+  memset(ws2812_buf, 0, sizeof(ws2812_buf));
+}
+
+/**
+ * @brief 退出低功耗，恢复数据脚为推挽输出
+ * @note  LED 电源将在下一次 WS2812_Update() 根据像素内容按需自动打开
+ */
+void WS2812_Wakeup(void) {
+  GPIOA_ModeCfg(WS2812_PIN, GPIO_ModeOut_PP_5mA);
+}

--- a/firmware/CH592F/jump_iap/Ld/Link.ld
+++ b/firmware/CH592F/jump_iap/Ld/Link.ld
@@ -18,4 +18,25 @@ SECTIONS
 		. = ALIGN(4);
 		_einit = .;
 	} >FLASH AT>FLASH
+
+	.vector :
+	{
+		. = ALIGN(4);
+		KEEP(*(.vector))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	.vector_handler :
+	{
+		. = ALIGN(4);
+		KEEP(*(.vector_handler))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	.handle_reset :
+	{
+		. = ALIGN(4);
+		KEEP(*(SORT_NONE(.handle_reset)))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
 }

--- a/firmware/CH592F/jump_iap/Startup/startup_CH592.S
+++ b/firmware/CH592F/jump_iap/Startup/startup_CH592.S
@@ -2,4 +2,111 @@
 	.global	_start
 	.align	1
 _start:
+	j	handle_reset
+
+	.section    .vector,"ax",@progbits
+	.align  1
+_vector_base:
+	.option norvc;
+
+	.word   0
+	.word   0
+	.word   NMI_Handler
+	.word   HardFault_Handler
+	.word   0xF5F9BDA9
+	.word   Ecall_M_Mode_Handler
+	.word   0
+	.word   0
+	.word   Ecall_U_Mode_Handler
+	.word   Break_Point_Handler
+	.word   0
+	.word   0
+	.word   SysTick_Handler
+	.word   0
+	.word   SW_Handler
+	.word   0
+	.word   TMR0_IRQHandler
+	.word   GPIOA_IRQHandler
+	.word   GPIOB_IRQHandler
+	.word   SPI0_IRQHandler
+	.word   BB_IRQHandler
+	.word   LLE_IRQHandler
+	.word   USB_IRQHandler
+	.word   0
+	.word   TMR1_IRQHandler
+	.word   TMR2_IRQHandler
+	.word   UART0_IRQHandler
+	.word   UART1_IRQHandler
+	.word   RTC_IRQHandler
+	.word   ADC_IRQHandler
+	.word   I2C_IRQHandler
+	.word   PWMX_IRQHandler
+	.word   TMR3_IRQHandler
+	.word   UART2_IRQHandler
+	.word   UART3_IRQHandler
+	.word   WDOG_BAT_IRQHandler
+
+	.option rvc;
+
+	.section    .vector_handler, "ax", @progbits
+	.weak   NMI_Handler
+	.weak   HardFault_Handler
+	.weak   Ecall_M_Mode_Handler
+	.weak   Ecall_U_Mode_Handler
+	.weak   Break_Point_Handler
+	.weak   SysTick_Handler
+	.weak   SW_Handler
+	.weak   TMR0_IRQHandler
+	.weak   GPIOA_IRQHandler
+	.weak   GPIOB_IRQHandler
+	.weak   SPI0_IRQHandler
+	.weak   BB_IRQHandler
+	.weak   LLE_IRQHandler
+	.weak   USB_IRQHandler
+	.weak   TMR1_IRQHandler
+	.weak   TMR2_IRQHandler
+	.weak   UART0_IRQHandler
+	.weak   UART1_IRQHandler
+	.weak   RTC_IRQHandler
+	.weak   ADC_IRQHandler
+	.weak   I2C_IRQHandler
+	.weak   PWMX_IRQHandler
+	.weak   TMR3_IRQHandler
+	.weak   UART2_IRQHandler
+	.weak   UART3_IRQHandler
+	.weak   WDOG_BAT_IRQHandler
+
+NMI_Handler:
+HardFault_Handler:
+Ecall_M_Mode_Handler:
+Ecall_U_Mode_Handler:
+Break_Point_Handler:
+SysTick_Handler:
+SW_Handler:
+TMR0_IRQHandler:
+GPIOA_IRQHandler:
+GPIOB_IRQHandler:
+SPI0_IRQHandler:
+BB_IRQHandler:
+LLE_IRQHandler:
+USB_IRQHandler:
+TMR1_IRQHandler:
+TMR2_IRQHandler:
+UART0_IRQHandler:
+UART1_IRQHandler:
+RTC_IRQHandler:
+ADC_IRQHandler:
+I2C_IRQHandler:
+PWMX_IRQHandler:
+TMR3_IRQHandler:
+UART2_IRQHandler:
+UART3_IRQHandler:
+WDOG_BAT_IRQHandler:
+1:
+	j 1b
+
+	.section	.handle_reset,"ax",@progbits
+	.weak	handle_reset
+	.align	1
+handle_reset:
 	j	0x6D000

--- a/firmware/CH592F/keyboard/include/kbd_rgb.h
+++ b/firmware/CH592F/keyboard/include/kbd_rgb.h
@@ -23,7 +23,8 @@
 #include "kbd_types.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /*============================================================================*/
@@ -34,175 +35,202 @@ extern "C" {
  */
 
 /** @name 蓝牙未连接 - 红色 */
-#define KBD_IND_BLE_DISCONN_R   255
-#define KBD_IND_BLE_DISCONN_G   0
-#define KBD_IND_BLE_DISCONN_B   0
+#define KBD_IND_BLE_DISCONN_R 255
+#define KBD_IND_BLE_DISCONN_G 0
+#define KBD_IND_BLE_DISCONN_B 0
 
 /** @name 蓝牙广播中 - 蓝色 */
-#define KBD_IND_BLE_ADV_R       0
-#define KBD_IND_BLE_ADV_G       0
-#define KBD_IND_BLE_ADV_B       255
+#define KBD_IND_BLE_ADV_R 0
+#define KBD_IND_BLE_ADV_G 0
+#define KBD_IND_BLE_ADV_B 255
 
 /** @name 蓝牙已连接 - 绿色 */
-#define KBD_IND_BLE_CONN_R      0
-#define KBD_IND_BLE_CONN_G      255
-#define KBD_IND_BLE_CONN_B      0
+#define KBD_IND_BLE_CONN_R 0
+#define KBD_IND_BLE_CONN_G 255
+#define KBD_IND_BLE_CONN_B 0
 
 /** @name USB 已连接 - 白色 */
-#define KBD_IND_USB_CONN_R      255
-#define KBD_IND_USB_CONN_G      255
-#define KBD_IND_USB_CONN_B      255
+#define KBD_IND_USB_CONN_R 255
+#define KBD_IND_USB_CONN_G 255
+#define KBD_IND_USB_CONN_B 255
 
 /** @name 低电量 - 琥珀橙 (区别于 BLE 断连红色) */
-#define KBD_IND_LOW_BATT_R      255
-#define KBD_IND_LOW_BATT_G      80
-#define KBD_IND_LOW_BATT_B      0
+#define KBD_IND_LOW_BATT_R 255
+#define KBD_IND_LOW_BATT_G 80
+#define KBD_IND_LOW_BATT_B 0
 
-/** @} */ /* end of KBD_RGB_Colors */
+/** @name 充电中 - 琥珀金 */
+#define KBD_IND_CHARGING_R 255
+#define KBD_IND_CHARGING_G 140
+#define KBD_IND_CHARGING_B 16
 
-/*============================================================================*/
-/**
- * @defgroup KBD_RGB_API RGB 控制接口
- * @{
- */
+/** @name 低功耗待机 - 蓝青 */
+#define KBD_IND_SLEEP_READY_R 0
+#define KBD_IND_SLEEP_READY_G 160
+#define KBD_IND_SLEEP_READY_B 255
 
-/**
- * @brief 初始化 RGB 灯效引擎
- *
- * 初始化 WS2812 驱动并加载 RGB 配置
- */
-void KBD_RGB_Init(void);
+/** @name 低功耗中 - 深蓝 */
+#define KBD_IND_SLEEPING_R 0
+#define KBD_IND_SLEEPING_G 48
+#define KBD_IND_SLEEPING_B 255
 
-/**
- * @brief RGB 效果处理函数
- *
- * 根据当前模式更新 LED 状态
- *
- * @note 由 TMOS 定时事件驱动，约每 20ms 调用一次
- */
-void KBD_RGB_Process(void);
+    /** @} */ /* end of KBD_RGB_Colors */
 
-/**
- * @brief 设置 RGB 模式
- *
- * @param[in] mode 目标模式 @ref kbd_rgb_mode_t
- */
-void KBD_RGB_SetMode(kbd_rgb_mode_t mode);
+    /*============================================================================*/
+    /**
+     * @defgroup KBD_RGB_API RGB 控制接口
+     * @{
+     */
 
-/**
- * @brief 获取当前 RGB 模式
- *
- * @return 当前模式 @ref kbd_rgb_mode_t
- */
-kbd_rgb_mode_t KBD_RGB_GetMode(void);
+    /**
+     * @brief 初始化 RGB 灯效引擎
+     *
+     * 初始化 WS2812 驱动并加载 RGB 配置
+     */
+    void KBD_RGB_Init(void);
 
-/**
- * @brief 切换到下一个模式
- */
-void KBD_RGB_NextMode(void);
+    /**
+     * @brief RGB 效果处理函数
+     *
+     * 根据当前模式更新 LED 状态
+     *
+     * @note 由 TMOS 定时事件驱动，约每 20ms 调用一次
+     */
+    void KBD_RGB_Process(void);
 
-/**
- * @brief 切换到上一个模式
- */
-void KBD_RGB_PrevMode(void);
+    /**
+     * @brief 设置 RGB 模式
+     *
+     * @param[in] mode 目标模式 @ref kbd_rgb_mode_t
+     */
+    void KBD_RGB_SetMode(kbd_rgb_mode_t mode);
 
-/**
- * @brief 开关 RGB
- *
- * 切换 RGB 总开关状态
- */
-void KBD_RGB_Toggle(void);
+    /**
+     * @brief 获取当前 RGB 模式
+     *
+     * @return 当前模式 @ref kbd_rgb_mode_t
+     */
+    kbd_rgb_mode_t KBD_RGB_GetMode(void);
 
-/**
- * @brief 设置 RGB/按键灯亮度
- *
- * @param[in] brightness 亮度值 (0-255)
- */
-void KBD_RGB_SetBrightness(uint8_t brightness);
+    /**
+     * @brief 切换到下一个模式
+     */
+    void KBD_RGB_NextMode(void);
 
-/**
- * @brief 设置指示灯亮度
- *
- * @param[in] brightness 亮度值 (0-255)
- */
-void KBD_RGB_SetIndicatorBrightness(uint8_t brightness);
+    /**
+     * @brief 切换到上一个模式
+     */
+    void KBD_RGB_PrevMode(void);
 
-/**
- * @brief 增加亮度
- *
- * @param[in] step 增量 (建议 16)
- */
-void KBD_RGB_BrightnessUp(uint8_t step);
+    /**
+     * @brief 开关 RGB
+     *
+     * 切换 RGB 总开关状态
+     */
+    void KBD_RGB_Toggle(void);
 
-/**
- * @brief 降低亮度
- *
- * @param[in] step 减量 (建议 16)
- */
-void KBD_RGB_BrightnessDown(uint8_t step);
+    /**
+     * @brief 设置 RGB/按键灯亮度
+     *
+     * @param[in] brightness 亮度值 (0-255)
+     */
+    void KBD_RGB_SetBrightness(uint8_t brightness);
 
-/**
- * @brief 设置静态颜色
- *
- * @param[in] r 红色分量 (0-255)
- * @param[in] g 绿色分量 (0-255)
- * @param[in] b 蓝色分量 (0-255)
- */
-void KBD_RGB_SetColor(uint8_t r, uint8_t g, uint8_t b);
+    /**
+     * @brief 设置指示灯亮度
+     *
+     * @param[in] brightness 亮度值 (0-255)
+     */
+    void KBD_RGB_SetIndicatorBrightness(uint8_t brightness);
 
-/**
- * @brief 设置动画速度
- *
- * @param[in] speed 速度值 (0=最慢, 255=最快)
- */
-void KBD_RGB_SetSpeed(uint8_t speed);
+    /**
+     * @brief 增加亮度
+     *
+     * @param[in] step 增量 (建议 16)
+     */
+    void KBD_RGB_BrightnessUp(uint8_t step);
 
-/**
- * @brief 设置状态指示
- *
- * 根据键盘当前状态设置指示灯颜色和效果
- *
- * @param[in] state 当前状态 @ref kbd_state_t
- */
-void KBD_RGB_SetState(kbd_state_t state);
+    /**
+     * @brief 降低亮度
+     *
+     * @param[in] step 减量 (建议 16)
+     */
+    void KBD_RGB_BrightnessDown(uint8_t step);
 
-/**
- * @brief 启用/禁用状态指示
- *
- * @param[in] enable true=启用, false=禁用
- */
-void KBD_RGB_EnableIndicator(bool enable);
+    /**
+     * @brief 设置静态颜色
+     *
+     * @param[in] r 红色分量 (0-255)
+     * @param[in] g 绿色分量 (0-255)
+     * @param[in] b 蓝色分量 (0-255)
+     */
+    void KBD_RGB_SetColor(uint8_t r, uint8_t g, uint8_t b);
 
-/**
- * @brief 临时闪烁指示
- *
- * 用于按键反馈或提示，闪烁后自动恢复原状态
- *
- * @param[in] r           红色分量
- * @param[in] g           绿色分量
- * @param[in] b           蓝色分量
- * @param[in] duration_ms 闪烁持续时间 (毫秒)
- */
-void KBD_RGB_Flash(uint8_t r, uint8_t g, uint8_t b, uint16_t duration_ms);
+    /**
+     * @brief 设置动画速度
+     *
+     * @param[in] speed 速度值 (0=最慢, 255=最快)
+     */
+    void KBD_RGB_SetSpeed(uint8_t speed);
 
-/**
- * @brief 层切换指示闪烁
- *
- * 切换层时，对应按键 LED 与指示灯同步闪烁 3 次（颜色为该层颜色）。
- * 闪烁结束后，按键灯恢复正常灯效，指示灯恢复状态显示。
- *
- * @param[in] layer 层号 (0-4)
- */
-void KBD_RGB_FlashLayer(uint8_t layer);
+    /**
+     * @brief 设置状态指示
+     *
+     * 根据键盘当前状态设置指示灯颜色和效果
+     *
+     * @param[in] state 当前状态 @ref kbd_state_t
+     */
+    void KBD_RGB_SetState(kbd_state_t state);
 
-/**
- * @brief 注册按键按下事件（用于按下效果）
- *
- * @param[in] key_index 按键索引 (0 ~ KBD_NUM_KEYS-1)
- */
-void KBD_RGB_RegisterKeyPress(uint8_t key_index);
+    /**
+     * @brief 启用/禁用状态指示
+     *
+     * @param[in] enable true=启用, false=禁用
+     */
+    void KBD_RGB_EnableIndicator(bool enable);
 
-/** @} */ /* end of KBD_RGB_API */
+    /**
+     * @brief 设置是否进入低功耗指示灯模式。
+     * @param enable true=仅保留指示灯动画，关闭按键灯；false=恢复正常 RGB 处理
+     */
+    void KBD_RGB_SetLowPower(bool enable);
+
+    /**
+     * @brief 暂停或恢复 RGB 周期任务。
+     * @param enable false=暂停周期刷新，true=恢复周期刷新
+     */
+    void KBD_RGB_SetSchedulerEnabled(bool enable);
+
+    /**
+     * @brief 临时闪烁指示
+     *
+     * 用于按键反馈或提示，闪烁后自动恢复原状态
+     *
+     * @param[in] r           红色分量
+     * @param[in] g           绿色分量
+     * @param[in] b           蓝色分量
+     * @param[in] duration_ms 闪烁持续时间 (毫秒)
+     */
+    void KBD_RGB_Flash(uint8_t r, uint8_t g, uint8_t b, uint16_t duration_ms);
+
+    /**
+     * @brief 层切换指示闪烁
+     *
+     * 切换层时，对应按键 LED 与指示灯同步闪烁 3 次（颜色为该层颜色）。
+     * 闪烁结束后，按键灯恢复正常灯效，指示灯恢复状态显示。
+     *
+     * @param[in] layer 层号 (0-4)
+     */
+    void KBD_RGB_FlashLayer(uint8_t layer);
+
+    /**
+     * @brief 注册按键按下事件（用于按下效果）
+     *
+     * @param[in] key_index 按键索引 (0 ~ KBD_NUM_KEYS-1)
+     */
+    void KBD_RGB_RegisterKeyPress(uint8_t key_index);
+
+    /** @} */ /* end of KBD_RGB_API */
 
 #ifdef __cplusplus
 }

--- a/firmware/CH592F/keyboard/include/kbd_types.h
+++ b/firmware/CH592F/keyboard/include/kbd_types.h
@@ -27,17 +27,18 @@
 #include "bk_version_config.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/**
- * @defgroup KBD_Constants 常量定义
- * @brief 系统级常量与限制
- * @{
- */
+  /**
+   * @defgroup KBD_Constants 常量定义
+   * @brief 系统级常量与限制
+   * @{
+   */
 
-#define KBD_CONFIG_MAGIC 0x4D454F57 /**< 配置魔数 "MEOW" */
-#define KBD_CONFIG_LAYOUT_ID 0x0102 /**< 本地 DataFlash 布局版本 */
+#define KBD_CONFIG_MAGIC 0x4D454F57             /**< 配置魔数 "MEOW" */
+#define KBD_CONFIG_LAYOUT_ID 0x0102             /**< 本地 DataFlash 布局版本 */
 #define KBD_CONFIG_VERSION KBD_CONFIG_LAYOUT_ID /**< 配置版本 */
 
 #define KBD_MAX_LAYERS 5  /**< 配置结构层数组容量上限 */
@@ -52,450 +53,477 @@ extern "C" {
 /**
  * @brief 设备信息常量
  */
-#define KBD_VENDOR_ID 0x413D  /**< USB Vendor ID */
-#define KBD_PRODUCT_ID 0x2107 /**< USB Product ID */
+#define KBD_VENDOR_ID 0x413D                        /**< USB Vendor ID */
+#define KBD_PRODUCT_ID 0x2107                       /**< USB Product ID */
 #define KBD_VERSION_MAJOR BK_FIRMWARE_VERSION_MAJOR /**< 固件主版本 */
 #define KBD_VERSION_MINOR BK_FIRMWARE_VERSION_MINOR /**< 固件次版本 */
 #define KBD_VERSION_PATCH BK_FIRMWARE_VERSION_PATCH /**< 固件补丁版本 */
 /** 主.次 版本 BCD 16 位，供 USB bcdDevice、BLE PnP 等使用，改主/次版本后自动同步 */
 #define KBD_VERSION_BCD16 ((KBD_VERSION_MAJOR << 8) | KBD_VERSION_MINOR)
 
-/** @} */ /* end of KBD_Constants */
+  /** @} */ /* end of KBD_Constants */
 
-/**
- * @defgroup KBD_Flash DataFlash 地址布局
- * @brief CH592F DataFlash (32KB) 存储分配
- * @{
- */
+  /**
+   * @defgroup KBD_Flash DataFlash 地址布局
+   * @brief CH592F DataFlash (32KB) 存储分配
+   * @{
+   */
 
-#define KBD_FLASH_BASE 0x00000       /**< DataFlash 基址 */
-#define KBD_FLASH_HEADER 0x00000     /**< 配置头偏移 (32B, 槽位内偏移) */
-#define KBD_FLASH_SYSTEM 0x00100     /**< 系统配置偏移 (64B, 槽位内偏移) */
-#define KBD_FLASH_KEYMAP 0x00200     /**< 按键映射偏移 (164B, 槽位内偏移) */
-#define KBD_FLASH_FNKEY 0x00300      /**< FN 键配置偏移 (32B, 槽位内偏移) */
-#define KBD_FLASH_RGB 0x00340        /**< RGB 配置偏移 (32B, 槽位内偏移) */
-#define KBD_FLASH_RESERVED 0x00400   /**< 单配置槽大小 / 下一页起始 (1KB) */
-#define KBD_FLASH_MACRO_BASE 0x01000 /**< 宏数据区起始（0x0000~0x0BFF 配置槽；0x0C00~0x0FFF runtime 热数据） */
-#define KBD_FLASH_MACRO_SIZE 0x02000 /**< MeowFS 宏数据区大小 (8KB) */
-#define KBD_FLASH_MACRO_PAGE 0x00100 /**< MeowFS 页大小 (256B) */
+#define KBD_FLASH_BASE 0x00000        /**< DataFlash 基址 */
+#define KBD_FLASH_HEADER 0x00000      /**< 配置头偏移 (32B, 槽位内偏移) */
+#define KBD_FLASH_SYSTEM 0x00100      /**< 系统配置偏移 (64B, 槽位内偏移) */
+#define KBD_FLASH_KEYMAP 0x00200      /**< 按键映射偏移 (164B, 槽位内偏移) */
+#define KBD_FLASH_FNKEY 0x00300       /**< FN 键配置偏移 (32B, 槽位内偏移) */
+#define KBD_FLASH_RGB 0x00340         /**< RGB 配置偏移 (32B, 槽位内偏移) */
+#define KBD_FLASH_RESERVED 0x00400    /**< 单配置槽大小 / 下一页起始 (1KB) */
+#define KBD_FLASH_MACRO_BASE 0x01000  /**< 宏数据区起始（0x0000~0x0BFF 配置槽；0x0C00~0x0FFF runtime 热数据） */
+#define KBD_FLASH_MACRO_SIZE 0x02000  /**< MeowFS 宏数据区大小 (8KB) */
+#define KBD_FLASH_MACRO_PAGE 0x00100  /**< MeowFS 页大小 (256B) */
 #define KBD_FLASH_MACRO_HEADER 0x0002 /**< MeowFS 头部大小 (marker + count) */
 
-/** @} */ /* end of KBD_Flash */
+  /** @} */ /* end of KBD_Flash */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_ActionTypes 按键动作类型
- * @brief 定义按键可执行的各类动作
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_ActionTypes 按键动作类型
+   * @brief 定义按键可执行的各类动作
+   * @{
+   */
 
-/**
- * @brief 按键动作类型枚举
- *
- * 每个物理按键可以映射到以下任意一种动作类型
- */
-typedef enum {
-  KBD_ACTION_NONE = 0x00,        /**< 无动作 */
-  KBD_ACTION_KEYBOARD = 0x01,    /**< 键盘按键 (修饰键 + 键码) */
-  KBD_ACTION_MOUSE_BTN = 0x02,   /**< 鼠标按键 */
-  KBD_ACTION_MOUSE_WHEEL = 0x03, /**< 鼠标滚轮 */
-  KBD_ACTION_CONSUMER = 0x04,    /**< 多媒体控制键 */
-  KBD_ACTION_MACRO = 0x05,       /**< 执行宏 */
-  KBD_ACTION_LAYER = 0x06,       /**< 层切换 */
-} kbd_action_type_t;
+  /**
+   * @brief 按键动作类型枚举
+   *
+   * 每个物理按键可以映射到以下任意一种动作类型
+   */
+  typedef enum
+  {
+    KBD_ACTION_NONE = 0x00,        /**< 无动作 */
+    KBD_ACTION_KEYBOARD = 0x01,    /**< 键盘按键 (修饰键 + 键码) */
+    KBD_ACTION_MOUSE_BTN = 0x02,   /**< 鼠标按键 */
+    KBD_ACTION_MOUSE_WHEEL = 0x03, /**< 鼠标滚轮 */
+    KBD_ACTION_CONSUMER = 0x04,    /**< 多媒体控制键 */
+    KBD_ACTION_MACRO = 0x05,       /**< 执行宏 */
+    KBD_ACTION_LAYER = 0x06,       /**< 层切换 */
+  } kbd_action_type_t;
 
-/**
- * @brief 鼠标滚轮方向
- */
-typedef enum {
-  KBD_WHEEL_NONE = 0,  /**< 无动作 */
-  KBD_WHEEL_UP = 1,    /**< 向上滚动一格 */
-  KBD_WHEEL_DOWN = 2,  /**< 向下滚动一格 */
-  KBD_WHEEL_CLICK = 3, /**< 中键点击 */
-} kbd_wheel_dir_t;
+  /**
+   * @brief 鼠标滚轮方向
+   */
+  typedef enum
+  {
+    KBD_WHEEL_NONE = 0,  /**< 无动作 */
+    KBD_WHEEL_UP = 1,    /**< 向上滚动一格 */
+    KBD_WHEEL_DOWN = 2,  /**< 向下滚动一格 */
+    KBD_WHEEL_CLICK = 3, /**< 中键点击 */
+  } kbd_wheel_dir_t;
 
-/**
- * @brief 鼠标按键掩码
- */
-typedef enum {
-  KBD_MOUSE_LEFT = 0x01,    /**< 左键 */
-  KBD_MOUSE_RIGHT = 0x02,   /**< 右键 */
-  KBD_MOUSE_MIDDLE = 0x04,  /**< 中键 */
-  KBD_MOUSE_BACK = 0x08,    /**< 后退键 */
-  KBD_MOUSE_FORWARD = 0x10, /**< 前进键 */
-} kbd_mouse_btn_t;
+  /**
+   * @brief 鼠标按键掩码
+   */
+  typedef enum
+  {
+    KBD_MOUSE_LEFT = 0x01,    /**< 左键 */
+    KBD_MOUSE_RIGHT = 0x02,   /**< 右键 */
+    KBD_MOUSE_MIDDLE = 0x04,  /**< 中键 */
+    KBD_MOUSE_BACK = 0x08,    /**< 后退键 */
+    KBD_MOUSE_FORWARD = 0x10, /**< 前进键 */
+  } kbd_mouse_btn_t;
 
-/**
- * @brief 层操作类型
- */
-typedef enum {
-  KBD_LAYER_MOMENTARY = 0, /**< 按住时切换，松开恢复 */
-  KBD_LAYER_TOGGLE = 1,    /**< 切换开关 */
-  KBD_LAYER_SET = 2,       /**< 直接设置为指定层 */
-} kbd_layer_op_t;
+  /**
+   * @brief 层操作类型
+   */
+  typedef enum
+  {
+    KBD_LAYER_MOMENTARY = 0, /**< 按住时切换，松开恢复 */
+    KBD_LAYER_TOGGLE = 1,    /**< 切换开关 */
+    KBD_LAYER_SET = 2,       /**< 直接设置为指定层 */
+  } kbd_layer_op_t;
 
-/** @} */ /* end of KBD_ActionTypes */
+  /** @} */ /* end of KBD_ActionTypes */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_KeyMapping 按键映射结构
- * @brief 定义按键到动作的映射关系
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_KeyMapping 按键映射结构
+   * @brief 定义按键到动作的映射关系
+   * @{
+   */
 
-/**
- * @brief 单键动作结构 (4 字节)
- *
- * @note 根据 type 字段，其他字段含义不同：
- * - KBD_ACTION_KEYBOARD: modifier=修饰键, param1=键码
- * - KBD_ACTION_MOUSE_BTN: param1=按键掩码
- * - KBD_ACTION_MOUSE_WHEEL: param1=滚轮方向
- * - KBD_ACTION_CONSUMER: param1=低字节, param2=高字节
- * - KBD_ACTION_MACRO: param1=宏ID
- * - KBD_ACTION_LAYER: modifier=操作类型, param1=层号
- */
-typedef struct __attribute__((packed)) {
-  uint8_t type;     /**< 动作类型 @ref kbd_action_type_t */
-  uint8_t modifier; /**< 修饰键或操作类型 */
-  uint8_t param1;   /**< 参数1 (键码/按键/方向/ID) */
-  uint8_t param2;   /**< 参数2 (多媒体键高字节) */
-} kbd_action_t;
+  /**
+   * @brief 单键动作结构 (4 字节)
+   *
+   * @note 根据 type 字段，其他字段含义不同：
+   * - KBD_ACTION_KEYBOARD: modifier=修饰键, param1=键码
+   * - KBD_ACTION_MOUSE_BTN: param1=按键掩码
+   * - KBD_ACTION_MOUSE_WHEEL: param1=滚轮方向
+   * - KBD_ACTION_CONSUMER: param1=低字节, param2=高字节
+   * - KBD_ACTION_MACRO: param1=宏ID
+   * - KBD_ACTION_LAYER: modifier=操作类型, param1=层号
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t type;     /**< 动作类型 @ref kbd_action_type_t */
+    uint8_t modifier; /**< 修饰键或操作类型 */
+    uint8_t param1;   /**< 参数1 (键码/按键/方向/ID) */
+    uint8_t param2;   /**< 参数2 (多媒体键高字节) */
+  } kbd_action_t;
 
-/**
- * @brief 单层按键映射 (32 字节)
- */
-typedef struct __attribute__((packed)) {
-  kbd_action_t keys[KBD_MAX_KEYS]; /**< 按键动作数组 */
-} kbd_layer_t;
+  /**
+   * @brief 单层按键映射 (32 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    kbd_action_t keys[KBD_MAX_KEYS]; /**< 按键动作数组 */
+  } kbd_layer_t;
 
-/**
- * @brief 完整按键映射配置 (164 字节)
- */
-typedef struct __attribute__((packed)) {
-  uint8_t num_layers;                 /**< 实际使用的层数 (1-KBD_MAX_LAYERS) */
-  uint8_t current_layer;              /**< 当前激活层 */
-  uint8_t default_layer;              /**< 默认层 */
-  uint8_t reserved;                   /**< 保留字段 */
-  kbd_layer_t layers[KBD_MAX_LAYERS]; /**< 层映射数组 */
-} kbd_keymap_t;
+  /**
+   * @brief 完整按键映射配置 (164 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t num_layers;                 /**< 实际使用的层数 (1-KBD_MAX_LAYERS) */
+    uint8_t current_layer;              /**< 当前激活层 */
+    uint8_t default_layer;              /**< 默认层 */
+    uint8_t reserved;                   /**< 保留字段 */
+    kbd_layer_t layers[KBD_MAX_LAYERS]; /**< 层映射数组 */
+  } kbd_keymap_t;
 
-/** @} */ /* end of KBD_KeyMapping */
+  /** @} */ /* end of KBD_KeyMapping */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_FnKey FN 功能键配置
- * @brief FN 键支持短按和长按两种动作
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_FnKey FN 功能键配置
+   * @brief FN 键支持短按和长按两种动作
+   * @{
+   */
 
-/**
- * @brief FN 键动作类型
- *
- * FN 键只执行系统功能，不发送 HID 报告
- */
-typedef enum {
-  KBD_FN_NONE = 0x00, /**< 无动作 */
+  /**
+   * @brief FN 键动作类型
+   *
+   * FN 键只执行系统功能，不发送 HID 报告
+   */
+  typedef enum
+  {
+    KBD_FN_NONE = 0x00, /**< 无动作 */
 
-  /* 模式控制 0x01-0x0F */
-  KBD_FN_MODE_TOGGLE = 0x01,     /**< USB/BLE 模式切换 */
-  KBD_FN_BLE_ADV = 0x02,         /**< 开始蓝牙广播 */
-  KBD_FN_BLE_DISCONNECT = 0x03,  /**< 断开蓝牙连接 */
-  KBD_FN_BLE_CLEAR_BONDS = 0x04, /**< 清除所有配对信息 */
+    /* 模式控制 0x01-0x0F */
+    KBD_FN_MODE_TOGGLE = 0x01,     /**< USB/BLE 模式切换 */
+    KBD_FN_BLE_ADV = 0x02,         /**< 开始蓝牙广播 */
+    KBD_FN_BLE_DISCONNECT = 0x03,  /**< 断开蓝牙连接 */
+    KBD_FN_BLE_CLEAR_BONDS = 0x04, /**< 清除所有配对信息 */
 
-  /* RGB 控制 0x10-0x1F */
-  KBD_FN_RGB_TOGGLE = 0x10,      /**< RGB 开关 */
-  KBD_FN_RGB_MODE_NEXT = 0x11,   /**< 下一个灯效模式 */
-  KBD_FN_RGB_MODE_PREV = 0x12,   /**< 上一个灯效模式 */
-  KBD_FN_RGB_BRIGHT_UP = 0x13,   /**< 增加亮度 */
-  KBD_FN_RGB_BRIGHT_DOWN = 0x14, /**< 降低亮度 */
+    /* RGB 控制 0x10-0x1F */
+    KBD_FN_RGB_TOGGLE = 0x10,      /**< RGB 开关 */
+    KBD_FN_RGB_MODE_NEXT = 0x11,   /**< 下一个灯效模式 */
+    KBD_FN_RGB_MODE_PREV = 0x12,   /**< 上一个灯效模式 */
+    KBD_FN_RGB_BRIGHT_UP = 0x13,   /**< 增加亮度 */
+    KBD_FN_RGB_BRIGHT_DOWN = 0x14, /**< 降低亮度 */
 
-  /* 层控制 0x20-0x2F */
-  KBD_FN_LAYER_NEXT = 0x20, /**< 切换到下一层 */
-  KBD_FN_LAYER_PREV = 0x21, /**< 切换到上一层 */
-  KBD_FN_LAYER_SET = 0x22,  /**< 设置为指定层 (param=层号) */
+    /* 层控制 0x20-0x2F */
+    KBD_FN_LAYER_NEXT = 0x20, /**< 切换到下一层 */
+    KBD_FN_LAYER_PREV = 0x21, /**< 切换到上一层 */
+    KBD_FN_LAYER_SET = 0x22,  /**< 设置为指定层 (param=层号) */
 
-  /* 宏 0x30-0x3F */
-  KBD_FN_MACRO = 0x30, /**< 执行宏 (param=宏ID) */
+    /* 宏 0x30-0x3F */
+    KBD_FN_MACRO = 0x30, /**< 执行宏 (param=宏ID) */
 
-  /* 系统 0x40-0x4F */
-  KBD_FN_SLEEP = 0x40,      /**< 进入睡眠模式 */
-  KBD_FN_BOOTLOADER = 0x41, /**< 进入 Bootloader */
-} kbd_fn_action_t;
+    /* 系统 0x40-0x4F */
+    KBD_FN_SLEEP = 0x40,      /**< 进入睡眠模式 */
+    KBD_FN_BOOTLOADER = 0x41, /**< 进入 Bootloader */
+  } kbd_fn_action_t;
 
-/**
- * @brief 单个 FN 键配置 (8 字节)
- */
-typedef struct __attribute__((packed)) {
-  uint8_t click_action;   /**< 短按动作 @ref kbd_fn_action_t */
-  uint8_t click_param;    /**< 短按参数 */
-  uint8_t long_action;    /**< 长按动作 @ref kbd_fn_action_t */
-  uint8_t long_param;     /**< 长按参数 */
-  uint16_t long_press_ms; /**< 长按判定阈值 (毫秒) */
-  uint8_t reserved[2];    /**< 保留字段 */
-} kbd_fnkey_entry_t;
+  /**
+   * @brief 单个 FN 键配置 (8 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t click_action;   /**< 短按动作 @ref kbd_fn_action_t */
+    uint8_t click_param;    /**< 短按参数 */
+    uint8_t long_action;    /**< 长按动作 @ref kbd_fn_action_t */
+    uint8_t long_param;     /**< 长按参数 */
+    uint16_t long_press_ms; /**< 长按判定阈值 (毫秒) */
+    uint8_t reserved[2];    /**< 保留字段 */
+  } kbd_fnkey_entry_t;
 
-/**
- * @brief FN 键配置集合 (32 字节)
- */
-typedef struct __attribute__((packed)) {
-  kbd_fnkey_entry_t fn[KBD_MAX_FN_KEYS]; /**< FN 键配置数组 */
-} kbd_fnkey_config_t;
+  /**
+   * @brief FN 键配置集合 (32 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    kbd_fnkey_entry_t fn[KBD_MAX_FN_KEYS]; /**< FN 键配置数组 */
+  } kbd_fnkey_config_t;
 
-/** @} */ /* end of KBD_FnKey */
+  /** @} */ /* end of KBD_FnKey */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_Macro 宏定义结构
- * @brief 宏支持键盘、鼠标、延时等多种动作
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_Macro 宏定义结构
+   * @brief 宏支持键盘、鼠标、延时等多种动作
+   * @{
+   */
 
-/**
- * @brief 宏触发模式
- *
- * 存储在 kbd_action_t.modifier 字段（当 type == KBD_ACTION_MACRO 时）
- */
-typedef enum {
-  KBD_MACRO_TRIG_ONCE = 0x00,        /**< 按下触发 1 次 */
-  KBD_MACRO_TRIG_HOLD_ABORT = 0x01,  /**< 按住循环，松开立即中断 */
-  KBD_MACRO_TRIG_HOLD_FINISH = 0x02, /**< 按住循环，松开跑完当轮再停 */
-  KBD_MACRO_TRIG_TOGGLE = 0x03,      /**< 按下开始循环，再按停（跑完当轮） */
-} kbd_macro_trigger_t;
+  /**
+   * @brief 宏触发模式
+   *
+   * 存储在 kbd_action_t.modifier 字段（当 type == KBD_ACTION_MACRO 时）
+   */
+  typedef enum
+  {
+    KBD_MACRO_TRIG_ONCE = 0x00,        /**< 按下触发 1 次 */
+    KBD_MACRO_TRIG_HOLD_ABORT = 0x01,  /**< 按住循环，松开立即中断 */
+    KBD_MACRO_TRIG_HOLD_FINISH = 0x02, /**< 按住循环，松开跑完当轮再停 */
+    KBD_MACRO_TRIG_TOGGLE = 0x03,      /**< 按下开始循环，再按停（跑完当轮） */
+  } kbd_macro_trigger_t;
 
-/**
- * @brief 宏动作类型
- *
- * @note 所有按键类动作都需要显式的 DOWN 和 UP 配对
- */
-typedef enum {
-  /* 键盘动作 0x01-0x0F */
-  KBD_MACRO_KEY_DOWN = 0x01, /**< 按下普通键 (param=键码) */
-  KBD_MACRO_KEY_UP = 0x02,   /**< 释放普通键 (param=键码) */
-  KBD_MACRO_MOD_DOWN = 0x03, /**< 按下修饰键 (param=修饰键掩码) */
-  KBD_MACRO_MOD_UP = 0x04,   /**< 释放修饰键 (param=修饰键掩码) */
+  /**
+   * @brief 宏动作类型
+   *
+   * @note 所有按键类动作都需要显式的 DOWN 和 UP 配对
+   */
+  typedef enum
+  {
+    /* 键盘动作 0x01-0x0F */
+    KBD_MACRO_KEY_DOWN = 0x01, /**< 按下普通键 (param=键码) */
+    KBD_MACRO_KEY_UP = 0x02,   /**< 释放普通键 (param=键码) */
+    KBD_MACRO_MOD_DOWN = 0x03, /**< 按下修饰键 (param=修饰键掩码) */
+    KBD_MACRO_MOD_UP = 0x04,   /**< 释放修饰键 (param=修饰键掩码) */
 
-  /* 延时 0x10-0x1F */
-  KBD_MACRO_DELAY = 0x10, /**< 延时 (param × 10ms, 最大 2550ms) */
+    /* 延时 0x10-0x1F */
+    KBD_MACRO_DELAY = 0x10, /**< 延时 (param × 10ms, 最大 2550ms) */
 
-  /* 多媒体 0x20-0x2F */
-  KBD_MACRO_CONSUMER = 0x20, /**< 多媒体键 (按下立即释放) */
+    /* 多媒体 0x20-0x2F */
+    KBD_MACRO_CONSUMER = 0x20, /**< 多媒体键 (按下立即释放) */
 
-  /* 鼠标 0x30-0x3F */
-  KBD_MACRO_MOUSE_DOWN = 0x30, /**< 鼠标按下 (param=按键掩码) */
-  KBD_MACRO_MOUSE_UP = 0x31,   /**< 鼠标释放 (param=按键掩码) */
-  KBD_MACRO_WHEEL = 0x32,      /**< 滚轮 (param=方向) */
+    /* 鼠标 0x30-0x3F */
+    KBD_MACRO_MOUSE_DOWN = 0x30, /**< 鼠标按下 (param=按键掩码) */
+    KBD_MACRO_MOUSE_UP = 0x31,   /**< 鼠标释放 (param=按键掩码) */
+    KBD_MACRO_WHEEL = 0x32,      /**< 滚轮 (param=方向) */
 
-  /* 结束标记 */
-  KBD_MACRO_END = 0xFF, /**< 宏结束 */
-} kbd_macro_action_type_t;
+    /* 结束标记 */
+    KBD_MACRO_END = 0xFF, /**< 宏结束 */
+  } kbd_macro_action_type_t;
 
-/**
- * @brief 宏动作单元 (2 字节)
- */
-typedef struct __attribute__((packed)) {
-  uint8_t type;  /**< 动作类型 @ref kbd_macro_action_type_t */
-  uint8_t param; /**< 动作参数 */
-} kbd_macro_action_t;
+  /**
+   * @brief 宏动作单元 (2 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t type;  /**< 动作类型 @ref kbd_macro_action_type_t */
+    uint8_t param; /**< 动作参数 */
+  } kbd_macro_action_t;
 
-/**
- * @brief 宏头部信息 (24 字节)
- *
- * 存储在 Flash 中，后接实际的动作数据
- */
-typedef struct __attribute__((packed)) {
-  uint8_t valid;         /**< 有效标记 (0xAA=有效) */
-  uint8_t id;            /**< 宏 ID (0-7) */
-  uint16_t action_count; /**< 动作数量 */
-  uint16_t data_size;    /**< 数据大小 (字节) */
-  uint8_t reserved[2];   /**< 保留字段 */
-  char name[16];         /**< 宏名称 (UTF-8, 空字符结尾) */
-} kbd_macro_header_t;
+  /**
+   * @brief 宏头部信息 (24 字节)
+   *
+   * 存储在 Flash 中，后接实际的动作数据
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t valid;         /**< 有效标记 (0xAA=有效) */
+    uint8_t id;            /**< 宏 ID (0-7) */
+    uint16_t action_count; /**< 动作数量 */
+    uint16_t data_size;    /**< 数据大小 (字节) */
+    uint8_t reserved[2];   /**< 保留字段 */
+    char name[16];         /**< 宏名称 (UTF-8, 空字符结尾) */
+  } kbd_macro_header_t;
 
-/** @} */ /* end of KBD_Macro */
+  /** @} */ /* end of KBD_Macro */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_RGB RGB 配置
- * @brief RGB 灯效模式与状态指示配置
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_RGB RGB 配置
+   * @brief RGB 灯效模式与状态指示配置
+   * @{
+   */
 
-/**
- * @brief RGB 灯效模式
- */
-typedef enum {
-  KBD_RGB_OFF = 0,       /**< 关闭 */
-  KBD_RGB_STATIC = 1,    /**< 静态单色 */
-  KBD_RGB_BREATHING = 2, /**< 呼吸效果 */
-  KBD_RGB_BLINK = 3,     /**< 闪烁效果 */
-  KBD_RGB_RAINBOW = 4,   /**< 彩虹渐变 */
-  KBD_RGB_INDICATOR = 5, /**< 状态指示模式 (最高优先级) */
-} kbd_rgb_mode_t;
+  /**
+   * @brief RGB 灯效模式
+   */
+  typedef enum
+  {
+    KBD_RGB_OFF = 0,       /**< 关闭 */
+    KBD_RGB_STATIC = 1,    /**< 静态单色 */
+    KBD_RGB_BREATHING = 2, /**< 呼吸效果 */
+    KBD_RGB_BLINK = 3,     /**< 闪烁效果 */
+    KBD_RGB_RAINBOW = 4,   /**< 彩虹渐变 */
+    KBD_RGB_INDICATOR = 5, /**< 状态指示模式 (最高优先级) */
+  } kbd_rgb_mode_t;
 
-/**
- * @brief RGB 状态指示类型
- *
- * 用于自动显示键盘当前状态
- */
-typedef enum {
-  KBD_STATE_USB_CONNECTED,    /**< USB 已连接 - 白色常亮 */
-  KBD_STATE_BLE_DISCONNECTED, /**< 蓝牙未连接 - 红色慢呼吸 */
-  KBD_STATE_BLE_ADVERTISING,  /**< 蓝牙广播中 - 蓝色呼吸 */
-  KBD_STATE_BLE_CONNECTED,    /**< 蓝牙已连接 - 绿色常亮 */
-  KBD_STATE_LOW_BATTERY,      /**< 低电量警告 - 红色快闪 */
-} kbd_state_t;
+  /**
+   * @brief RGB 状态指示类型
+   *
+   * 用于自动显示键盘当前状态
+   */
+  typedef enum
+  {
+    KBD_STATE_USB_CONNECTED,    /**< USB 已连接 - 白色常亮 */
+    KBD_STATE_BLE_DISCONNECTED, /**< 蓝牙未连接 - 红色慢呼吸 */
+    KBD_STATE_BLE_ADVERTISING,  /**< 蓝牙广播中 - 蓝色呼吸 */
+    KBD_STATE_BLE_CONNECTED,    /**< 蓝牙已连接 - 绿色常亮 */
+    KBD_STATE_LOW_BATTERY,      /**< 低电量警告 - 红色快闪 */
+    KBD_STATE_CHARGING,         /**< 充电中 - 琥珀色短脉冲 */
+    KBD_STATE_SLEEP_READY,      /**< 低功耗待机 - 蓝青色短呼吸 */
+    KBD_STATE_SLEEPING,         /**< 低功耗中 - 蓝色短闪后熄灭 */
+  } kbd_state_t;
 
 /** @brief 默认亮度 20% (255 * 20 / 100 ≈ 51) */
 #define KBD_RGB_DEFAULT_BRIGHTNESS 51
 
-/**
- * @brief RGB 配置结构 (32 字节)
- */
-typedef struct __attribute__((packed)) {
-  uint8_t enabled;              /**< RGB 总开关 */
-  uint8_t mode;                 /**< 灯效模式 @ref kbd_rgb_mode_t */
-  uint8_t brightness;           /**< RGB/按键灯亮度 (0-255) */
-  uint8_t speed;                /**< 动画速度 (0-255) */
-  uint8_t color_r;              /**< 静态颜色 - 红 */
-  uint8_t color_g;              /**< 静态颜色 - 绿 */
-  uint8_t color_b;              /**< 静态颜色 - 蓝 */
-  uint8_t indicator_enabled;    /**< 状态指示开关 */
-  uint8_t indicator_brightness; /**< 指示灯亮度 (0-255) */
-  uint8_t press_effect;         /**< 按下效果 (0=无, 1=亮起渐灭, 2=熄灭渐亮) */
-  uint8_t reserved[22];         /**< 保留字段 */
-} kbd_rgb_config_t;
+  /**
+   * @brief RGB 配置结构 (32 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t enabled;              /**< RGB 总开关 */
+    uint8_t mode;                 /**< 灯效模式 @ref kbd_rgb_mode_t */
+    uint8_t brightness;           /**< RGB/按键灯亮度 (0-255) */
+    uint8_t speed;                /**< 动画速度 (0-255) */
+    uint8_t color_r;              /**< 静态颜色 - 红 */
+    uint8_t color_g;              /**< 静态颜色 - 绿 */
+    uint8_t color_b;              /**< 静态颜色 - 蓝 */
+    uint8_t indicator_enabled;    /**< 状态指示开关 */
+    uint8_t indicator_brightness; /**< 指示灯亮度 (0-255) */
+    uint8_t press_effect;         /**< 按下效果 (0=无, 1=亮起渐灭, 2=熄灭渐亮) */
+    uint8_t reserved[22];         /**< 保留字段 */
+  } kbd_rgb_config_t;
 
-/** @} */ /* end of KBD_RGB */
+  /** @} */ /* end of KBD_RGB */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_System 系统配置
- * @brief 系统级配置参数
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_System 系统配置
+   * @brief 系统级配置参数
+   * @{
+   */
 
-/**
- * @brief 系统配置结构 (64 字节)
- */
-typedef struct __attribute__((packed)) {
-  uint8_t default_mode;        /**< 默认工作模式 (0=USB, 1=BLE) */
-  uint8_t auto_sleep_min;      /**< 自动休眠时间 (分钟, 0=禁用) */
-  uint8_t debounce_ms;         /**< 按键消抖时间 (毫秒) */
-  /* HID 日志配置 (v1.2+) */
-  uint8_t log_enabled;         /**< HID 日志开关 (0=关, 非0=开, 默认1) */
-  uint8_t reserved[60];        /**< 保留字段 */
-} kbd_system_config_t;
+  /**
+   * @brief 系统配置结构 (64 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t default_mode;   /**< 默认工作模式 (0=USB, 1=BLE) */
+    uint8_t auto_sleep_min; /**< 自动休眠时间 (分钟, 0=禁用) */
+    uint8_t debounce_ms;    /**< 按键消抖时间 (毫秒) */
+    /* HID 日志配置 (v1.2+) */
+    uint8_t log_enabled;  /**< HID 日志开关 (0=关, 非0=开, 默认1) */
+    uint8_t reserved[60]; /**< 保留字段 */
+  } kbd_system_config_t;
 
-/**
- * @brief 配置头部结构 (32 字节)
- *
- * 用于验证配置有效性和版本兼容性
- */
-typedef struct __attribute__((packed)) {
-  uint32_t magic;       /**< 魔数 @ref KBD_CONFIG_MAGIC */
-  uint16_t version;     /**< 配置版本 */
-  uint16_t flags;       /**< 标志位 */
-  uint32_t crc32;       /**< 数据校验码 */
-  uint32_t save_count;  /**< 保存计数 */
-  uint8_t reserved[16]; /**< 保留字段 */
-} kbd_config_header_t;
+  /**
+   * @brief 配置头部结构 (32 字节)
+   *
+   * 用于验证配置有效性和版本兼容性
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint32_t magic;       /**< 魔数 @ref KBD_CONFIG_MAGIC */
+    uint16_t version;     /**< 配置版本 */
+    uint16_t flags;       /**< 标志位 */
+    uint32_t crc32;       /**< 数据校验码 */
+    uint32_t save_count;  /**< 保存计数 */
+    uint8_t reserved[16]; /**< 保留字段 */
+  } kbd_config_header_t;
 
-/** @} */ /* end of KBD_System */
+  /** @} */ /* end of KBD_System */
 
-/*============================================================================*/
-/**
- * @defgroup KBD_Protocol HID 通讯协议
- * @brief USB HID 配置命令定义
- * @{
- */
+  /*============================================================================*/
+  /**
+   * @defgroup KBD_Protocol HID 通讯协议
+   * @brief USB HID 配置命令定义
+   * @{
+   */
 
-/**
- * @brief HID 命令码
- */
-typedef enum {
-  /* 系统命令 0x01-0x0F */
-  KBD_CMD_SYS_INFO = 0x01,   /**< 获取设备信息 */
-  KBD_CMD_SYS_STATUS = 0x02, /**< 获取运行状态 */
+  /**
+   * @brief HID 命令码
+   */
+  typedef enum
+  {
+    /* 系统命令 0x01-0x0F */
+    KBD_CMD_SYS_INFO = 0x01,   /**< 获取设备信息 */
+    KBD_CMD_SYS_STATUS = 0x02, /**< 获取运行状态 */
 
-  /* 配置管理 0x10-0x1F */
-  KBD_CMD_CFG_SAVE = 0x10,  /**< 保存配置到 Flash */
-  KBD_CMD_CFG_LOAD = 0x11,  /**< 从 Flash 加载配置 */
-  KBD_CMD_CFG_RESET = 0x12, /**< 恢复出厂设置 */
+    /* 配置管理 0x10-0x1F */
+    KBD_CMD_CFG_SAVE = 0x10,  /**< 保存配置到 Flash */
+    KBD_CMD_CFG_LOAD = 0x11,  /**< 从 Flash 加载配置 */
+    KBD_CMD_CFG_RESET = 0x12, /**< 恢复出厂设置 */
 
-  /* 按键映射 0x20-0x2F */
-  KBD_CMD_KEYMAP_GET = 0x20, /**< 获取按键映射 */
-  KBD_CMD_KEYMAP_SET = 0x21, /**< 设置按键映射 */
-  KBD_CMD_LAYER_GET = 0x22,  /**< 获取当前层信息 */
-  KBD_CMD_LAYER_SET = 0x23,  /**< 设置当前层 */
+    /* 按键映射 0x20-0x2F */
+    KBD_CMD_KEYMAP_GET = 0x20, /**< 获取按键映射 */
+    KBD_CMD_KEYMAP_SET = 0x21, /**< 设置按键映射 */
+    KBD_CMD_LAYER_GET = 0x22,  /**< 获取当前层信息 */
+    KBD_CMD_LAYER_SET = 0x23,  /**< 设置当前层 */
 
-  /* RGB 控制 0x30-0x3F */
-  KBD_CMD_RGB_GET = 0x30, /**< 获取 RGB 配置 */
-  KBD_CMD_RGB_SET = 0x31, /**< 设置 RGB 配置 */
+    /* RGB 控制 0x30-0x3F */
+    KBD_CMD_RGB_GET = 0x30, /**< 获取 RGB 配置 */
+    KBD_CMD_RGB_SET = 0x31, /**< 设置 RGB 配置 */
 
-  /* 宏管理 0x40-0x4F */
-  KBD_CMD_MACRO_INFO = 0x40, /**< 获取宏信息 */
-  KBD_CMD_MACRO_GET = 0x41,  /**< 读取宏数据 */
-  KBD_CMD_MACRO_SET = 0x42,  /**< 写入宏数据 (分包传输) */
-  KBD_CMD_MACRO_DEL = 0x43,  /**< 删除宏 */
+    /* 宏管理 0x40-0x4F */
+    KBD_CMD_MACRO_INFO = 0x40, /**< 获取宏信息 */
+    KBD_CMD_MACRO_GET = 0x41,  /**< 读取宏数据 */
+    KBD_CMD_MACRO_SET = 0x42,  /**< 写入宏数据 (分包传输) */
+    KBD_CMD_MACRO_DEL = 0x43,  /**< 删除宏 */
 
-  /* FN 键配置 0x50-0x5F */
-  KBD_CMD_FNKEY_GET = 0x50, /**< 获取 FN 键配置 */
-  KBD_CMD_FNKEY_SET = 0x51, /**< 设置 FN 键配置 */
+    /* FN 键配置 0x50-0x5F */
+    KBD_CMD_FNKEY_GET = 0x50, /**< 获取 FN 键配置 */
+    KBD_CMD_FNKEY_SET = 0x51, /**< 设置 FN 键配置 */
 
-  /* 电源管理 0x60-0x6F */
-  KBD_CMD_BATTERY = 0x60, /**< 获取电池信息 */
+    /* 电源管理 0x60-0x6F */
+    KBD_CMD_BATTERY = 0x60, /**< 获取电池信息 */
 
-  /* 设备日志 0x70-0x7F */
-  KBD_CMD_LOG = 0x70,     /**< 设备日志推送 (设备 → 主机, 异步) */
-  KBD_CMD_LOG_GET = 0x71, /**< 获取日志配置 */
-  KBD_CMD_LOG_SET = 0x72, /**< 设置日志配置 */
-} kbd_cmd_t;
+    /* 设备日志 0x70-0x7F */
+    KBD_CMD_LOG = 0x70,     /**< 设备日志推送 (设备 → 主机, 异步) */
+    KBD_CMD_LOG_GET = 0x71, /**< 获取日志配置 */
+    KBD_CMD_LOG_SET = 0x72, /**< 设置日志配置 */
+  } kbd_cmd_t;
 
-/**
- * @brief HID 日志类别 (KBD_CMD_LOG 的 SUB 字段)
- */
-typedef enum {
-  KBD_LOG_KEY_EVENT    = 0x01, /**< 按键按下/释放 */
-  KBD_LOG_FN_EVENT     = 0x02, /**< FN 键单击/长按 */
-  KBD_LOG_LAYER_EVENT  = 0x03, /**< 层切换 */
-  KBD_LOG_MODE_EVENT   = 0x04, /**< USB/BLE 模式切换 */
-  KBD_LOG_BLE_EVENT    = 0x05, /**< 蓝牙状态变化 */
-  KBD_LOG_RGB_EVENT    = 0x06, /**< RGB 模式变化 */
-  KBD_LOG_SYSTEM_EVENT = 0x07, /**< 系统事件 */
-} kbd_log_category_t;
+  /**
+   * @brief HID 日志类别 (KBD_CMD_LOG 的 SUB 字段)
+   */
+  typedef enum
+  {
+    KBD_LOG_KEY_EVENT = 0x01,    /**< 按键按下/释放 */
+    KBD_LOG_FN_EVENT = 0x02,     /**< FN 键单击/长按 */
+    KBD_LOG_LAYER_EVENT = 0x03,  /**< 层切换 */
+    KBD_LOG_MODE_EVENT = 0x04,   /**< USB/BLE 模式切换 */
+    KBD_LOG_BLE_EVENT = 0x05,    /**< 蓝牙状态变化 */
+    KBD_LOG_RGB_EVENT = 0x06,    /**< RGB 模式变化 */
+    KBD_LOG_SYSTEM_EVENT = 0x07, /**< 系统事件 */
+  } kbd_log_category_t;
 
-/**
- * @brief 系统事件子类型
- */
-typedef enum {
-  KBD_LOG_SYS_BOOT   = 0x01, /**< 设备启动 */
-  KBD_LOG_SYS_SLEEP  = 0x02, /**< 进入休眠 */
-  KBD_LOG_SYS_WAKEUP = 0x03, /**< 唤醒 */
-} kbd_log_sys_event_t;
+  /**
+   * @brief 系统事件子类型
+   */
+  typedef enum
+  {
+    KBD_LOG_SYS_BOOT = 0x01,   /**< 设备启动 */
+    KBD_LOG_SYS_SLEEP = 0x02,  /**< 进入休眠 */
+    KBD_LOG_SYS_WAKEUP = 0x03, /**< 唤醒 */
+  } kbd_log_sys_event_t;
 
-/**
- * @brief HID 响应码
- */
-typedef enum {
-  KBD_RESP_OK = 0x00,            /**< 成功 */
-  KBD_RESP_ERR_INVALID = 0x01,   /**< 无效命令 */
-  KBD_RESP_ERR_PARAM = 0x02,     /**< 参数错误 */
-  KBD_RESP_ERR_BUSY = 0x03,      /**< 设备忙 */
-  KBD_RESP_ERR_FLASH = 0x04,     /**< Flash 操作失败 */
-  KBD_RESP_ERR_TOO_LARGE = 0x10, /**< 数据过大 */
-  KBD_RESP_ERR_NO_SPACE = 0x11,  /**< 存储空间不足 */
-  KBD_RESP_ERR_NOT_FOUND = 0x12, /**< 未找到目标 */
-} kbd_resp_t;
+  /**
+   * @brief HID 响应码
+   */
+  typedef enum
+  {
+    KBD_RESP_OK = 0x00,            /**< 成功 */
+    KBD_RESP_ERR_INVALID = 0x01,   /**< 无效命令 */
+    KBD_RESP_ERR_PARAM = 0x02,     /**< 参数错误 */
+    KBD_RESP_ERR_BUSY = 0x03,      /**< 设备忙 */
+    KBD_RESP_ERR_FLASH = 0x04,     /**< Flash 操作失败 */
+    KBD_RESP_ERR_TOO_LARGE = 0x10, /**< 数据过大 */
+    KBD_RESP_ERR_NO_SPACE = 0x11,  /**< 存储空间不足 */
+    KBD_RESP_ERR_NOT_FOUND = 0x12, /**< 未找到目标 */
+  } kbd_resp_t;
 
-/**
- * @brief HID 命令帧结构 (64 字节)
- */
-typedef struct __attribute__((packed)) {
-  uint8_t cmd;      /**< 命令码 @ref kbd_cmd_t */
-  uint8_t sub;      /**< 子命令/序号 */
-  uint8_t len;      /**< 数据长度 */
-  uint8_t data[61]; /**< 数据区 */
-} kbd_cmd_frame_t;
+  /**
+   * @brief HID 命令帧结构 (64 字节)
+   */
+  typedef struct __attribute__((packed))
+  {
+    uint8_t cmd;      /**< 命令码 @ref kbd_cmd_t */
+    uint8_t sub;      /**< 子命令/序号 */
+    uint8_t len;      /**< 数据长度 */
+    uint8_t data[61]; /**< 数据区 */
+  } kbd_cmd_frame_t;
 
 /** @} */ /* end of KBD_Protocol */
 
@@ -516,7 +544,7 @@ typedef struct __attribute__((packed)) {
 #define KBD_WHEEL(dir) {KBD_ACTION_MOUSE_WHEEL, 0, (dir), 0}
 
 /** @brief 创建多媒体键动作 */
-#define KBD_CONSUMER(code)                                                     \
+#define KBD_CONSUMER(code) \
   {KBD_ACTION_CONSUMER, 0, (code) & 0xFF, ((code) >> 8)}
 
 /** @brief 创建宏动作 */
@@ -538,7 +566,7 @@ typedef struct __attribute__((packed)) {
 #define KBD_MOD_RALT 0x40   /**< 右 Alt */
 #define KBD_MOD_RGUI 0x80   /**< 右 GUI */
 
-/** @} */ /* end of KBD_Helpers */
+  /** @} */ /* end of KBD_Helpers */
 
 #ifdef __cplusplus
 }

--- a/firmware/CH592F/keyboard/include/kbd_types.h
+++ b/firmware/CH592F/keyboard/include/kbd_types.h
@@ -38,7 +38,7 @@ extern "C"
    */
 
 #define KBD_CONFIG_MAGIC 0x4D454F57             /**< 配置魔数 "MEOW" */
-#define KBD_CONFIG_LAYOUT_ID 0x0102             /**< 本地 DataFlash 布局版本 */
+#define KBD_CONFIG_LAYOUT_ID 0x0103             /**< 本地 DataFlash 布局版本 */
 #define KBD_CONFIG_VERSION KBD_CONFIG_LAYOUT_ID /**< 配置版本 */
 
 #define KBD_MAX_LAYERS 5  /**< 配置结构层数组容量上限 */
@@ -400,12 +400,13 @@ extern "C"
    */
   typedef struct __attribute__((packed))
   {
-    uint8_t default_mode;   /**< 默认工作模式 (0=USB, 1=BLE) */
-    uint8_t auto_sleep_min; /**< 自动休眠时间 (分钟, 0=禁用) */
-    uint8_t debounce_ms;    /**< 按键消抖时间 (毫秒) */
+    uint8_t default_mode;    /**< 默认工作模式 (0=USB, 1=BLE) */
+    uint8_t auto_sleep_min;  /**< LIGHT 休眠时间 (分钟, 0=禁用) */
+    uint8_t debounce_ms;     /**< 按键消抖时间 (毫秒) */
     /* HID 日志配置 (v1.2+) */
-    uint8_t log_enabled;  /**< HID 日志开关 (0=关, 非0=开, 默认1) */
-    uint8_t reserved[60]; /**< 保留字段 */
+    uint8_t log_enabled;     /**< HID 日志开关 (0=关, 非0=开, 默认1) */
+    uint8_t deep_sleep_min;  /**< DEEP 延时 (在 LIGHT 后, 分钟, 0=禁用) */
+    uint8_t reserved[59];    /**< 保留字段 */
   } kbd_system_config_t;
 
   /**

--- a/firmware/CH592F/keyboard/src/kbd_command.c
+++ b/firmware/CH592F/keyboard/src/kbd_command.c
@@ -422,8 +422,9 @@ static void HandleLayerSet(const kbd_cmd_frame_t *frame)
 static void HandleRgbGet(const kbd_cmd_frame_t *frame)
 {
   kbd_rgb_config_t *rgb = KBD_GetRgbConfig();
+  kbd_system_config_t *sys = KBD_GetSystemConfig();
 
-  uint8_t resp[12];
+  uint8_t resp[13];
   resp[0] = KBD_RESP_OK;
   resp[1] = rgb->enabled;
   resp[2] = rgb->mode;
@@ -435,8 +436,10 @@ static void HandleRgbGet(const kbd_cmd_frame_t *frame)
   resp[8] = rgb->indicator_enabled;
   resp[9] = rgb->indicator_brightness;
   resp[10] = rgb->press_effect;
+  resp[11] = sys->auto_sleep_min;
+  resp[12] = sys->deep_sleep_min;
 
-  KBD_Command_SendResponse(KBD_CMD_RGB_GET, 0, resp, 11);
+  KBD_Command_SendResponse(KBD_CMD_RGB_GET, 0, resp, 13);
 }
 
 /**
@@ -445,37 +448,45 @@ static void HandleRgbGet(const kbd_cmd_frame_t *frame)
 static void HandleRgbSet(const kbd_cmd_frame_t *frame)
 {
   kbd_rgb_config_t *rgb = KBD_GetRgbConfig();
+  kbd_system_config_t *sys = KBD_GetSystemConfig();
+  const uint8_t expected_len = 12;
 
-  if (frame->len >= 8)
+  if (frame->len != expected_len)
   {
-    rgb->enabled = frame->data[0];
-    rgb->mode = frame->data[1];
-    rgb->brightness = frame->data[2];
-    rgb->speed = frame->data[3];
-    rgb->color_r = frame->data[4];
-    rgb->color_g = frame->data[5];
-    rgb->color_b = frame->data[6];
-    rgb->indicator_enabled = 1; /* 指示灯始终启用，不允许用户关闭 */
-    /* indicator_brightness: 兼容旧协议，若 data[8] 存在则使用，低于最低值则提升
-     */
-    if (frame->len >= 9)
-    {
-      uint8_t v = frame->data[8];
-      rgb->indicator_brightness =
-          (v < KBD_INDICATOR_MIN_BRIGHTNESS) ? KBD_INDICATOR_MIN_BRIGHTNESS : v;
-    }
-    if (frame->len >= 10)
-    {
-      uint8_t pe = frame->data[9];
-      rgb->press_effect = (pe <= 2) ? pe : 0;
-    }
-
-    KBD_RGB_SetMode((kbd_rgb_mode_t)rgb->mode);
-    KBD_RGB_SetBrightness(rgb->brightness);
-    KBD_RGB_SetIndicatorBrightness(rgb->indicator_brightness);
-
-    KBD_Config_Save();
+    uint8_t resp[1] = {KBD_RESP_ERR_PARAM};
+    LOG_W(TAG, "RGB set data invalid: len=%d need=%d", frame->len, expected_len);
+    KBD_Command_SendResponse(KBD_CMD_RGB_SET, 0, resp, 1);
+    return;
   }
+
+  rgb->enabled = frame->data[0];
+  rgb->mode = frame->data[1];
+  rgb->brightness = frame->data[2];
+  rgb->speed = frame->data[3];
+  rgb->color_r = frame->data[4];
+  rgb->color_g = frame->data[5];
+  rgb->color_b = frame->data[6];
+  rgb->indicator_enabled = 1; /* 指示灯始终启用，不允许用户关闭 */
+
+  {
+    uint8_t v = frame->data[8];
+    rgb->indicator_brightness =
+        (v < KBD_INDICATOR_MIN_BRIGHTNESS) ? KBD_INDICATOR_MIN_BRIGHTNESS : v;
+  }
+
+  {
+    uint8_t pe = frame->data[9];
+    rgb->press_effect = (pe <= 2) ? pe : 0;
+  }
+
+  sys->auto_sleep_min = frame->data[10];
+  sys->deep_sleep_min = frame->data[11];
+
+  KBD_RGB_SetMode((kbd_rgb_mode_t)rgb->mode);
+  KBD_RGB_SetBrightness(rgb->brightness);
+  KBD_RGB_SetIndicatorBrightness(rgb->indicator_brightness);
+
+  KBD_Config_Save();
 
   uint8_t resp[1] = {KBD_RESP_OK};
   KBD_Command_SendResponse(KBD_CMD_RGB_SET, 0, resp, 1);

--- a/firmware/CH592F/keyboard/src/kbd_core.c
+++ b/firmware/CH592F/keyboard/src/kbd_core.c
@@ -27,6 +27,7 @@
 static uint8_t s_pressed_keys[6] = {0};
 static uint8_t s_pressed_count = 0;
 static uint8_t s_current_modifier = 0;
+static bool s_boot_key_prev_pressed = false;
 
 /*============================================================================*/
 /* 私有函数声明 */
@@ -37,6 +38,7 @@ static void ExecuteFnAction(kbd_fn_action_t action, uint8_t param);
 static void OnModeChange(kbd_work_mode_t new_mode);
 static void OnConnStateChange(kbd_conn_state_t state);
 static void OnLedReport(uint8_t leds);
+static void KBD_Core_ProcessBootKey(void);
 
 /*============================================================================*/
 /* 模式管理回调结构 */
@@ -59,8 +61,10 @@ void KBD_Core_Init(void)
 {
     s_pressed_count = 0;
     s_current_modifier = 0;
+    s_boot_key_prev_pressed = (BootKey_IsPressed() == 1);
 
-    for (uint8_t i = 0; i < 6; i++) {
+    for (uint8_t i = 0; i < 6; i++)
+    {
         s_pressed_keys[i] = 0;
     }
 
@@ -75,18 +79,23 @@ void KBD_Core_Process(void)
     key_event_t key_evt;
     fnkey_event_t fn_evt;
 
+    KBD_Core_ProcessBootKey();
+
     /* 处理普通按键事件 */
-    while (Key_GetEvent(&key_evt)) {
+    while (Key_GetEvent(&key_evt))
+    {
         KBD_Core_HandleKeyEvent(&key_evt);
     }
 
     /* 处理旋钮事件 */
-    while (Encoder_GetEvent(&key_evt)) {
+    while (Encoder_GetEvent(&key_evt))
+    {
         KBD_Core_HandleKeyEvent(&key_evt);
     }
 
     /* 处理 FN 按键事件 */
-    while (FnKey_GetEvent(&fn_evt)) {
+    while (FnKey_GetEvent(&fn_evt))
+    {
         KBD_Core_HandleFnEvent(&fn_evt);
     }
 }
@@ -96,12 +105,32 @@ void KBD_Core_Process(void)
  */
 static bool IsFnKeyHeld(void)
 {
-    for (uint8_t i = 0; i < KBD_MAX_FN_KEYS; i++) {
-        if (FnKey_IsDown(i) == 1) {
+    for (uint8_t i = 0; i < KBD_MAX_FN_KEYS; i++)
+    {
+        if (FnKey_IsDown(i) == 1)
+        {
             return true;
         }
     }
     return false;
+}
+
+static void KBD_Core_ProcessBootKey(void)
+{
+#if KBD_BOOT_KEY_ENTER_BOOTLOADER
+    bool pressed = (BootKey_IsPressed() == 1);
+
+    if (pressed && !s_boot_key_prev_pressed)
+    {
+        LOG_W(TAG, "BOOT: enter IAP");
+        KBD_Core_ReleaseAll();
+        KBD_RGB_Flash(255, 140, 0, 120);
+        mDelaymS(120);
+        Hal_JumpToBootloader();
+    }
+
+    s_boot_key_prev_pressed = pressed;
+#endif
 }
 
 /**
@@ -112,33 +141,39 @@ void KBD_Core_HandleKeyEvent(const key_event_t *evt)
     if (evt == NULL || evt->key >= KBD_MAX_KEYS)
         return;
 
+    KBD_Mode_RecordActivity();
+
     bool pressed = (evt->type == KEY_EVT_PRESS);
-    
+
     /* 按下效果：记录按键事件到 RGB 引擎 */
-    if (pressed) {
+    if (pressed)
+    {
         KBD_RGB_RegisterKeyPress(evt->key);
     }
 
     /* FN 组合键：按住 FN + 按键 = 切换到对应层 */
-    if (IsFnKeyHeld() && pressed) {
-        uint8_t target_layer = evt->key;  /* 按键0->层0, 按键1->层1... */
+    if (IsFnKeyHeld() && pressed)
+    {
+        uint8_t target_layer = evt->key; /* 按键0->层0, 按键1->层1... */
         kbd_keymap_t *keymap = KBD_GetKeymap();
 
-        if (target_layer < keymap->num_layers) {
+        if (target_layer < keymap->num_layers)
+        {
             uint8_t old_layer = keymap->current_layer;
             KBD_SetCurrentLayer(target_layer);
             LOG_I(TAG, "FN+Key%d -> Layer %d", evt->key, target_layer);
             KBD_Log_LayerEvent(old_layer, target_layer);
             KBD_RGB_FlashLayer(target_layer);
             /* 标记所有按住的 FN 键: 松开时不触发 click/long */
-            for (uint8_t i = 0; i < KBD_MAX_FN_KEYS; i++) {
+            for (uint8_t i = 0; i < KBD_MAX_FN_KEYS; i++)
+            {
                 if (FnKey_IsDown(i) == 1)
                     FnKey_MarkComboUsed(i);
             }
-            return;  /* 不执行按键原本的动作 */
+            return; /* 不执行按键原本的动作 */
         }
     }
-    
+
     const kbd_action_t *action = KBD_GetKeyAction(evt->key);
     if (action == NULL)
         return;
@@ -156,14 +191,19 @@ void KBD_Core_HandleFnEvent(const fnkey_event_t *evt)
     if (evt == NULL || evt->id >= KBD_MAX_FN_KEYS)
         return;
 
+    KBD_Mode_RecordActivity();
+
     kbd_fnkey_config_t *fnkey_cfg = KBD_GetFnKeyConfig();
     kbd_fnkey_entry_t *entry = &fnkey_cfg->fn[evt->id];
 
-    if (evt->type == FNKEY_EVT_LONG) {
+    if (evt->type == FNKEY_EVT_LONG)
+    {
         LOG_D(TAG, "FN%d long", evt->id + 1);
         KBD_Log_FnEvent(evt->id, 1, entry->long_action, entry->long_param);
         ExecuteFnAction((kbd_fn_action_t)entry->long_action, entry->long_param);
-    } else {
+    }
+    else
+    {
         LOG_D(TAG, "FN%d click", evt->id + 1);
         KBD_Log_FnEvent(evt->id, 0, entry->click_action, entry->click_param);
         ExecuteFnAction((kbd_fn_action_t)entry->click_action, entry->click_param);
@@ -177,7 +217,8 @@ void KBD_Core_ReleaseAll(void)
 {
     s_pressed_count = 0;
     s_current_modifier = 0;
-    for (uint8_t i = 0; i < 6; i++) {
+    for (uint8_t i = 0; i < 6; i++)
+    {
         s_pressed_keys[i] = 0;
     }
     KBD_Mode_ReleaseAllKeys();
@@ -208,16 +249,22 @@ static void OnModeChange(kbd_work_mode_t new_mode)
     KBD_Core_ReleaseAll();
 
     /* RGB 状态指示 + 切换确认闪烁（200ms） */
-    if (new_mode == KBD_WORK_MODE_USB) {
-        KBD_RGB_Flash(255, 255, 255, 200);   /* 白色短闪 = 进入 USB 模式 */
+    if (new_mode == KBD_WORK_MODE_USB)
+    {
+        KBD_RGB_Flash(255, 255, 255, 200); /* 白色短闪 = 进入 USB 模式 */
         KBD_RGB_SetState(KBD_STATE_USB_CONNECTED);
-    } else {
-        KBD_RGB_Flash(0, 80, 255, 200);      /* 蓝色短闪 = 进入 BLE 模式 */
+    }
+    else
+    {
+        KBD_RGB_Flash(0, 80, 255, 200); /* 蓝色短闪 = 进入 BLE 模式 */
         /* 根据实际连接状态设置指示灯，避免覆盖已进入广播的蓝色状态 */
         kbd_conn_state_t conn = KBD_Mode_GetConnState();
-        if (conn == KBD_CONN_ADVERTISING) {
+        if (conn == KBD_CONN_ADVERTISING)
+        {
             KBD_RGB_SetState(KBD_STATE_BLE_ADVERTISING);
-        } else {
+        }
+        else
+        {
             KBD_RGB_SetState(KBD_STATE_BLE_DISCONNECTED);
         }
     }
@@ -232,10 +279,14 @@ static void OnConnStateChange(kbd_conn_state_t state)
     KBD_Log_BleEvent((uint8_t)state);
 
     /* RGB 状态指示 */
-    if (KBD_Mode_Get() == KBD_WORK_MODE_USB) {
+    if (KBD_Mode_Get() == KBD_WORK_MODE_USB)
+    {
         KBD_RGB_SetState(KBD_STATE_USB_CONNECTED);
-    } else {
-        switch (state) {
+    }
+    else
+    {
+        switch (state)
+        {
         case KBD_CONN_DISCONNECTED:
             KBD_RGB_SetState(KBD_STATE_BLE_DISCONNECTED);
             break;
@@ -276,18 +327,25 @@ static void ExecuteKeyAction(const kbd_action_t *action, bool pressed)
     switch (action->type)
     {
     case KBD_ACTION_KEYBOARD:
-        if (pressed) {
+        if (pressed)
+        {
             /* 按下：添加按键 */
-            if (s_pressed_count < 6) {
+            if (s_pressed_count < 6)
+            {
                 s_pressed_keys[s_pressed_count++] = action->param1;
             }
             s_current_modifier |= action->modifier;
             KBD_Mode_SendKeyboardReport(s_current_modifier, s_pressed_keys, s_pressed_count);
-        } else {
+        }
+        else
+        {
             /* 释放：移除按键 */
-            for (uint8_t i = 0; i < s_pressed_count; i++) {
-                if (s_pressed_keys[i] == action->param1) {
-                    for (uint8_t j = i; j < s_pressed_count - 1; j++) {
+            for (uint8_t i = 0; i < s_pressed_count; i++)
+            {
+                if (s_pressed_keys[i] == action->param1)
+                {
+                    for (uint8_t j = i; j < s_pressed_count - 1; j++)
+                    {
                         s_pressed_keys[j] = s_pressed_keys[j + 1];
                     }
                     s_pressed_count--;
@@ -295,26 +353,34 @@ static void ExecuteKeyAction(const kbd_action_t *action, bool pressed)
                 }
             }
             s_current_modifier &= ~action->modifier;
-            if (s_pressed_count > 0) {
+            if (s_pressed_count > 0)
+            {
                 KBD_Mode_SendKeyboardReport(s_current_modifier, s_pressed_keys, s_pressed_count);
-            } else {
+            }
+            else
+            {
                 KBD_Mode_ReleaseAllKeys();
             }
         }
         break;
 
     case KBD_ACTION_MOUSE_BTN:
-        if (pressed) {
+        if (pressed)
+        {
             KBD_Mode_SendMouseReport(action->param1, 0, 0, 0);
-        } else {
+        }
+        else
+        {
             KBD_Mode_SendMouseReport(0, 0, 0, 0);
         }
         break;
 
     case KBD_ACTION_MOUSE_WHEEL:
-        if (pressed) {
+        if (pressed)
+        {
             int8_t wheel = 0;
-            switch (action->param1) {
+            switch (action->param1)
+            {
             case KBD_WHEEL_UP:
                 wheel = 1;
                 break;
@@ -327,48 +393,61 @@ static void ExecuteKeyAction(const kbd_action_t *action, bool pressed)
                 KBD_Mode_SendMouseReport(0, 0, 0, 0);
                 return;
             }
-            if (wheel != 0) {
+            if (wheel != 0)
+            {
                 KBD_Mode_SendMouseReport(0, 0, 0, wheel);
             }
         }
         break;
 
     case KBD_ACTION_CONSUMER:
+    {
+        uint16_t consumer_code = action->param1 | (action->param2 << 8);
+        if (pressed)
         {
-            uint16_t consumer_code = action->param1 | (action->param2 << 8);
-            if (pressed) {
-                KBD_Mode_SendConsumerReport(consumer_code);
-            } else {
-                KBD_Mode_SendConsumerReport(0);
-            }
+            KBD_Mode_SendConsumerReport(consumer_code);
         }
-        break;
+        else
+        {
+            KBD_Mode_SendConsumerReport(0);
+        }
+    }
+    break;
 
     case KBD_ACTION_LAYER:
-        if (pressed) {
+        if (pressed)
+        {
             uint8_t old_l = KBD_GetCurrentLayer();
             KBD_SetCurrentLayer(action->param1);
             LOG_I(TAG, "Layer -> %d", action->param1);
             KBD_Log_LayerEvent(old_l, action->param1);
             /* 切层时停止正在运行的宏 */
-            if (KBD_Macro_IsRunning()) {
+            if (KBD_Macro_IsRunning())
+            {
                 KBD_Macro_Cancel();
             }
         }
         break;
 
     case KBD_ACTION_MACRO:
-        if (pressed) {
+        if (pressed)
+        {
             kbd_macro_trigger_t trig = (kbd_macro_trigger_t)action->modifier;
-            if (trig == KBD_MACRO_TRIG_TOGGLE && KBD_Macro_IsRunning()) {
+            if (trig == KBD_MACRO_TRIG_TOGGLE && KBD_Macro_IsRunning())
+            {
                 KBD_Macro_Cancel(); /* Toggle 模式: 再按 → 停 */
-            } else {
+            }
+            else
+            {
                 int ret = KBD_Macro_Execute(action->param1, trig);
-                if (ret != 0) {
+                if (ret != 0)
+                {
                     LOG_W(TAG, "Macro %d exec fail: %d", action->param1, ret);
                 }
             }
-        } else {
+        }
+        else
+        {
             /* 松开事件通知宏引擎 */
             KBD_Macro_OnKeyRelease();
         }
@@ -395,17 +474,20 @@ static void ExecuteFnAction(kbd_fn_action_t action, uint8_t param)
     case KBD_FN_MODE_TOGGLE:
         LOG_I(TAG, "FN: mode toggle");
         ret = KBD_Mode_Toggle();
-        if (ret != 0) {
+        if (ret != 0)
+        {
             LOG_W(TAG, "mode toggle failed: %d", ret);
             KBD_RGB_Flash(255, 0, 0, 200);
         }
         break;
 
     case KBD_FN_BLE_ADV:
-        if (KBD_Mode_Get() == KBD_WORK_MODE_BLE && !KBD_Mode_IsConnected()) {
+        if (KBD_Mode_Get() == KBD_WORK_MODE_BLE && !KBD_Mode_IsConnected())
+        {
             LOG_I(TAG, "FN: start adv");
             ret = KBD_Mode_BLE_StartAdvertising();
-            if (ret != 0) {
+            if (ret != 0)
+            {
                 LOG_W(TAG, "start adv failed: %d", ret);
                 KBD_RGB_Flash(255, 0, 0, 200);
             }
@@ -415,21 +497,26 @@ static void ExecuteFnAction(kbd_fn_action_t action, uint8_t param)
     case KBD_FN_BLE_DISCONNECT:
         LOG_I(TAG, "FN: disconnect");
         ret = KBD_Mode_BLE_Disconnect();
-        if (ret != 0) {
+        if (ret != 0)
+        {
             LOG_W(TAG, "disconnect failed: %d", ret);
         }
         break;
 
     case KBD_FN_BLE_CLEAR_BONDS:
-        if (KBD_Mode_Get() != KBD_WORK_MODE_BLE) {
+        if (KBD_Mode_Get() != KBD_WORK_MODE_BLE)
+        {
             /* 非 BLE 模式：按用户要求静默忽略 */
             break;
         }
         LOG_I(TAG, "FN: clear bonds");
         ret = KBD_Mode_BLE_ClearBonds();
-        if (ret == 0) {
+        if (ret == 0)
+        {
             KBD_RGB_Flash(0, 120, 255, 300);
-        } else {
+        }
+        else
+        {
             LOG_W(TAG, "clear bonds failed: %d", ret);
             KBD_RGB_Flash(255, 0, 0, 300);
         }
@@ -463,25 +550,28 @@ static void ExecuteFnAction(kbd_fn_action_t action, uint8_t param)
 
     /* 层控制 */
     case KBD_FN_LAYER_NEXT:
-        {
-            if (KBD_Macro_IsRunning()) KBD_Macro_Cancel();
-            uint8_t layer = KBD_NextLayer();
-            LOG_I(TAG, "FN: layer next -> %d", layer);
-            KBD_RGB_FlashLayer(layer);
-        }
-        break;
+    {
+        if (KBD_Macro_IsRunning())
+            KBD_Macro_Cancel();
+        uint8_t layer = KBD_NextLayer();
+        LOG_I(TAG, "FN: layer next -> %d", layer);
+        KBD_RGB_FlashLayer(layer);
+    }
+    break;
 
     case KBD_FN_LAYER_PREV:
-        {
-            if (KBD_Macro_IsRunning()) KBD_Macro_Cancel();
-            uint8_t layer = KBD_PrevLayer();
-            LOG_I(TAG, "FN: layer prev -> %d", layer);
-            KBD_RGB_FlashLayer(layer);
-        }
-        break;
+    {
+        if (KBD_Macro_IsRunning())
+            KBD_Macro_Cancel();
+        uint8_t layer = KBD_PrevLayer();
+        LOG_I(TAG, "FN: layer prev -> %d", layer);
+        KBD_RGB_FlashLayer(layer);
+    }
+    break;
 
     case KBD_FN_LAYER_SET:
-        if (KBD_Macro_IsRunning()) KBD_Macro_Cancel();
+        if (KBD_Macro_IsRunning())
+            KBD_Macro_Cancel();
         LOG_I(TAG, "FN: layer set %d", param);
         KBD_SetCurrentLayer(param);
         KBD_RGB_FlashLayer(param);

--- a/firmware/CH592F/keyboard/src/kbd_rgb.c
+++ b/firmware/CH592F/keyboard/src/kbd_rgb.c
@@ -70,6 +70,9 @@ static uint8_t s_layer_flash_layer = 0; /**< 闪烁的目标按键位置 (层号
 /** @brief 层颜色表 */
 static const uint8_t s_layer_colors[5][3] = KBD_LAYER_COLORS;
 
+/** @brief 层号到提示按键的映射表 */
+static const uint8_t s_layer_to_key[KBD_DEFAULT_LAYERS] = KBD_LAYER_TO_KEY_MAP;
+
 /** @brief 逻辑按键到物理 LED 映射表 */
 static const uint8_t s_logical_to_physical[KBD_NUM_KEYS] = KBD_LOGICAL_TO_PHYSICAL_MAP;
 
@@ -92,6 +95,13 @@ static inline uint8_t KeyToLed(uint8_t key_idx)
     if (key_idx >= KBD_NUM_KEYS)
         return 0;
     return (WS2812_LED_NUM > 1) ? (s_logical_to_physical[key_idx] + 1) : 0;
+}
+
+static inline uint8_t LayerToLed(uint8_t layer_idx)
+{
+    if (layer_idx >= KBD_DEFAULT_LAYERS)
+        return 0;
+    return KeyToLed(s_layer_to_key[layer_idx]);
 }
 
 /*============================================================================*/
@@ -705,7 +715,7 @@ void KBD_RGB_Process(void)
                 {
                     s_layer_flash_is_on = true;
                     WS2812_FillKeys(0, 0, 0);
-                    WS2812_Set(KeyToLed(s_layer_flash_layer), s_layer_flash_r, s_layer_flash_g, s_layer_flash_b);
+                    WS2812_Set(LayerToLed(s_layer_flash_layer), s_layer_flash_r, s_layer_flash_g, s_layer_flash_b);
                     s_layer_flash_wait_ticks = LAYER_FLASH_TICKS_PER_100MS;
                 }
             }
@@ -987,7 +997,7 @@ void KBD_RGB_FlashLayer(uint8_t layer)
 
     /* 仅点亮对应层号位置的按键灯，其余熄灭；指示灯保持独立 */
     WS2812_FillKeys(0, 0, 0);
-    WS2812_Set(KeyToLed(layer), s_layer_flash_r, s_layer_flash_g, s_layer_flash_b);
+    WS2812_Set(LayerToLed(layer), s_layer_flash_r, s_layer_flash_g, s_layer_flash_b);
     ProcessIndicatorMode();
     WS2812_Update();
 }

--- a/firmware/CH592F/keyboard/src/kbd_rgb.c
+++ b/firmware/CH592F/keyboard/src/kbd_rgb.c
@@ -44,6 +44,9 @@ static kbd_state_t s_current_state = KBD_STATE_USB_CONNECTED;
 /** @brief 效果相位计数器 */
 static uint32_t s_effect_phase = 0;
 
+/** @brief 当前状态已持续时长 (毫秒) */
+static uint32_t s_state_elapsed_ms = 0;
+
 /** @brief 临时闪烁激活标志 */
 static bool s_flash_active = false;
 
@@ -73,6 +76,12 @@ static const uint8_t s_logical_to_physical[KBD_NUM_KEYS] = KBD_LOGICAL_TO_PHYSIC
 /** @brief TMOS 任务 ID */
 static tmosTaskID s_rgb_task_id = TASK_NO_TASK;
 
+/** @brief 低功耗指示灯模式：仅驱动指示灯，不驱动按键灯 */
+static bool s_low_power_active = false;
+
+/** @brief RGB 周期任务是否启用 */
+static bool s_scheduler_enabled = true;
+
 /**
  * @brief 将逻辑按键索引转换为 WS2812 LED 索引
  * @param key_idx 逻辑按键索引 (0 ~ KBD_NUM_KEYS-1)
@@ -80,7 +89,8 @@ static tmosTaskID s_rgb_task_id = TASK_NO_TASK;
  */
 static inline uint8_t KeyToLed(uint8_t key_idx)
 {
-    if (key_idx >= KBD_NUM_KEYS) return 0;
+    if (key_idx >= KBD_NUM_KEYS)
+        return 0;
     return (WS2812_LED_NUM > 1) ? (s_logical_to_physical[key_idx] + 1) : 0;
 }
 
@@ -89,9 +99,9 @@ static inline uint8_t KeyToLed(uint8_t key_idx)
 /*============================================================================*/
 
 /** @brief 按下效果常量 */
-#define PRESS_EFFECT_NONE       0
+#define PRESS_EFFECT_NONE 0
 #define PRESS_EFFECT_LIGHT_FADE 1
-#define PRESS_EFFECT_DARK_FADE  2
+#define PRESS_EFFECT_DARK_FADE 2
 
 /** @brief 每个按键的按下衰减值 (255=刚按下, 0=无效果) */
 static uint8_t s_press_fade[KBD_NUM_KEYS];
@@ -240,9 +250,12 @@ static void ProcessPressEffects(kbd_rgb_config_t *cfg)
             uint8_t pb = ((uint16_t)s_press_color_b[i] * intensity) >> 8;
             uint8_t br, bg, bb;
             SampleModeKeyColor(cfg, i, false, &br, &bg, &bb);
-            if (pr > br) br = pr;
-            if (pg > bg) bg = pg;
-            if (pb > bb) bb = pb;
+            if (pr > br)
+                br = pr;
+            if (pg > bg)
+                bg = pg;
+            if (pb > bb)
+                bb = pb;
             WS2812_Set(led_idx, br, bg, bb);
         }
         else
@@ -282,7 +295,10 @@ static uint16_t KBD_RGB_ProcessEvent(uint8_t task_id, uint16_t events)
     if (events & RGB_UPDATE_EVT)
     {
         KBD_RGB_Process();
-        tmos_start_task(s_rgb_task_id, RGB_UPDATE_EVT, MS1_TO_SYSTEM_TIME(RGB_UPDATE_INTERVAL_MS));
+        if (s_scheduler_enabled)
+        {
+            tmos_start_task(s_rgb_task_id, RGB_UPDATE_EVT, MS1_TO_SYSTEM_TIME(RGB_UPDATE_INTERVAL_MS));
+        }
         return (events ^ RGB_UPDATE_EVT);
     }
     return 0;
@@ -344,7 +360,8 @@ static bool CalcBlink(uint8_t phase)
  * @param[out] period_ms 动画周期 (毫秒)
  */
 static void GetIndicatorParams(kbd_state_t state, uint8_t *r, uint8_t *g, uint8_t *b,
-                               uint8_t *effect, uint16_t *period_ms)
+                               uint8_t *effect, uint16_t *period_ms,
+                               uint16_t *active_ms, bool *repeat)
 {
     switch (state)
     {
@@ -354,6 +371,8 @@ static void GetIndicatorParams(kbd_state_t state, uint8_t *r, uint8_t *g, uint8_
         *b = KBD_IND_USB_CONN_B;
         *effect = 0; /* 常亮 */
         *period_ms = 0;
+        *active_ms = 600;
+        *repeat = false;
         break;
 
     case KBD_STATE_BLE_DISCONNECTED:
@@ -362,6 +381,8 @@ static void GetIndicatorParams(kbd_state_t state, uint8_t *r, uint8_t *g, uint8_
         *b = KBD_IND_BLE_DISCONN_B;
         *effect = 1;       /* 呼吸 */
         *period_ms = 2000; /* 2 秒周期 */
+        *active_ms = 2000;
+        *repeat = true;
         break;
 
     case KBD_STATE_BLE_ADVERTISING:
@@ -370,6 +391,8 @@ static void GetIndicatorParams(kbd_state_t state, uint8_t *r, uint8_t *g, uint8_
         *b = KBD_IND_BLE_ADV_B;
         *effect = 1;       /* 呼吸 */
         *period_ms = 1000; /* 1 秒周期 */
+        *active_ms = 1000;
+        *repeat = true;
         break;
 
     case KBD_STATE_BLE_CONNECTED:
@@ -378,6 +401,8 @@ static void GetIndicatorParams(kbd_state_t state, uint8_t *r, uint8_t *g, uint8_
         *b = KBD_IND_BLE_CONN_B;
         *effect = 0; /* 常亮 */
         *period_ms = 0;
+        *active_ms = 600;
+        *repeat = false;
         break;
 
     case KBD_STATE_LOW_BATTERY:
@@ -386,12 +411,46 @@ static void GetIndicatorParams(kbd_state_t state, uint8_t *r, uint8_t *g, uint8_
         *b = KBD_IND_LOW_BATT_B;
         *effect = 2; /* 快闪 */
         *period_ms = 500;
+        *active_ms = 500;
+        *repeat = true;
+        break;
+
+    case KBD_STATE_CHARGING:
+        *r = KBD_IND_CHARGING_R;
+        *g = KBD_IND_CHARGING_G;
+        *b = KBD_IND_CHARGING_B;
+        *effect = 1; /* 短呼吸脉冲 */
+        *period_ms = 3000;
+        *active_ms = 700;
+        *repeat = true;
+        break;
+
+    case KBD_STATE_SLEEP_READY:
+        *r = KBD_IND_SLEEP_READY_R;
+        *g = KBD_IND_SLEEP_READY_G;
+        *b = KBD_IND_SLEEP_READY_B;
+        *effect = 1; /* 短呼吸 */
+        *period_ms = 900;
+        *active_ms = 900;
+        *repeat = false;
+        break;
+
+    case KBD_STATE_SLEEPING:
+        *r = KBD_IND_SLEEPING_R;
+        *g = KBD_IND_SLEEPING_G;
+        *b = KBD_IND_SLEEPING_B;
+        *effect = 2; /* 短闪 */
+        *period_ms = 280;
+        *active_ms = 280;
+        *repeat = false;
         break;
 
     default:
         *r = *g = *b = 0;
         *effect = 0;
         *period_ms = 0;
+        *active_ms = 0;
+        *repeat = false;
         break;
     }
 }
@@ -410,21 +469,34 @@ static void ProcessIndicatorMode(void)
 
     uint8_t r, g, b, effect;
     uint16_t period_ms;
-    GetIndicatorParams(s_current_state, &r, &g, &b, &effect, &period_ms);
+    uint16_t active_ms;
+    bool repeat;
+    GetIndicatorParams(s_current_state, &r, &g, &b, &effect, &period_ms,
+                       &active_ms, &repeat);
 
     uint8_t brightness = cfg->indicator_brightness;
+    uint32_t phase_ms = repeat && period_ms > 0 ? (s_state_elapsed_ms % period_ms)
+                                                : s_state_elapsed_ms;
+
+    if (active_ms > 0 && phase_ms >= active_ms)
+    {
+        WS2812_Clear_Indicator();
+        return;
+    }
 
     if (effect == 1 && period_ms > 0)
     {
         /* 呼吸效果 */
-        uint8_t phase = (s_effect_phase * 256 / period_ms) & 0xFF;
+        uint16_t window_ms = (active_ms > 0) ? active_ms : period_ms;
+        uint8_t phase = (phase_ms * 256 / window_ms) & 0xFF;
         brightness = CalcBreathing(phase);
         brightness = ((uint16_t)brightness * cfg->indicator_brightness) >> 8;
     }
     else if (effect == 2 && period_ms > 0)
     {
         /* 闪烁效果 */
-        uint8_t phase = (s_effect_phase * 256 / period_ms) & 0xFF;
+        uint16_t window_ms = (active_ms > 0) ? active_ms : period_ms;
+        uint8_t phase = (phase_ms * 256 / window_ms) & 0xFF;
         if (!CalcBlink(phase))
         {
             brightness = 0;
@@ -557,6 +629,7 @@ void KBD_RGB_Init(void)
     }
 
     s_effect_phase = 0;
+    s_state_elapsed_ms = 0;
     s_flash_active = false;
     s_layer_flash_active = false;
     ClearPressEffects();
@@ -579,6 +652,11 @@ void KBD_RGB_Process(void)
     if (s_effect_phase > 10000)
     {
         s_effect_phase = s_effect_phase % 10000;
+    }
+
+    if (s_state_elapsed_ms < 60000)
+    {
+        s_state_elapsed_ms += RGB_UPDATE_INTERVAL_MS;
     }
 
     /* 处理临时闪烁 */
@@ -639,6 +717,17 @@ void KBD_RGB_Process(void)
             WS2812_Update();
             return;
         }
+    }
+
+    if (s_low_power_active)
+    {
+        if (WS2812_LED_NUM > 1)
+        {
+            WS2812_FillKeys(0, 0, 0);
+        }
+        WS2812_Clear_Indicator();
+        WS2812_Update();
+        return;
     }
 
     /* 检测按下效果状态 */
@@ -815,6 +904,7 @@ void KBD_RGB_SetState(kbd_state_t state)
     {
         s_current_state = state;
         s_effect_phase = 0;
+        s_state_elapsed_ms = 0;
         LOG_D(TAG, "state=%d", state);
     }
 }
@@ -823,6 +913,49 @@ void KBD_RGB_EnableIndicator(bool enable)
 {
     kbd_rgb_config_t *cfg = KBD_GetRgbConfig();
     cfg->indicator_enabled = enable ? 1 : 0;
+}
+
+void KBD_RGB_SetLowPower(bool enable)
+{
+    if (s_low_power_active == enable)
+    {
+        return;
+    }
+
+    s_low_power_active = enable;
+    if (enable)
+    {
+        s_layer_flash_active = false;
+        s_flash_active = false;
+        ClearPressEffects();
+        /* 彻底切断 WS2812 总电源 + 数据脚置高阻，避免 ESD 漏流 */
+        WS2812_Sleep();
+    }
+    else
+    {
+        /* 数据脚恢复推挽输出；LED 电源由后续 WS2812_Update 按需打开 */
+        WS2812_Wakeup();
+        s_effect_phase = 0;
+        s_state_elapsed_ms = 0;
+    }
+}
+
+void KBD_RGB_SetSchedulerEnabled(bool enable)
+{
+    if (s_scheduler_enabled == enable)
+    {
+        return;
+    }
+
+    s_scheduler_enabled = enable;
+    if (!enable)
+    {
+        tmos_stop_task(s_rgb_task_id, RGB_UPDATE_EVT);
+        return;
+    }
+
+    tmos_stop_task(s_rgb_task_id, RGB_UPDATE_EVT);
+    tmos_start_task(s_rgb_task_id, RGB_UPDATE_EVT, MS1_TO_SYSTEM_TIME(RGB_UPDATE_INTERVAL_MS));
 }
 
 void KBD_RGB_Flash(uint8_t r, uint8_t g, uint8_t b, uint16_t duration_ms)

--- a/firmware/CH592F/keyboard/src/kbd_storage.c
+++ b/firmware/CH592F/keyboard/src/kbd_storage.c
@@ -254,9 +254,10 @@ static const kbd_rgb_config_t s_default_rgb = {
  */
 static const kbd_system_config_t s_default_system = {
     .default_mode = 0,          /* USB */
-    .auto_sleep_min = 5,        /* 5 分钟 */
+    .auto_sleep_min = 1,        /* LIGHT 默认 1 分钟 */
     .debounce_ms = 10,          /* 10ms */
     .log_enabled = KBD_LOG_DEFAULT_ENABLED, /* HID 日志默认开关由构建类型决定 */
+    .deep_sleep_min = 1,        /* DEEP 默认在 LIGHT 后 1 分钟 */
 };
 
 /*============================================================================*/
@@ -577,7 +578,7 @@ static bool TryLoadConfigSlot(uint8_t slot, kbd_config_slot_cache_t *out) {
   if (out->header.magic != KBD_CONFIG_MAGIC) {
     return false;
   }
-  if ((out->header.version >> 8) != (KBD_CONFIG_VERSION >> 8)) {
+  if (out->header.version != KBD_CONFIG_VERSION) {
     return false;
   }
 
@@ -589,24 +590,6 @@ static bool TryLoadConfigSlot(uint8_t slot, kbd_config_slot_cache_t *out) {
     return false;
   }
 
-  return true;
-}
-
-static bool TryLoadConfigAtAddr(uint32_t base_addr, uint8_t slot_tag,
-                                kbd_config_slot_cache_t *out) {
-  memset(out, 0, sizeof(*out));
-  out->slot = slot_tag;
-  EEPROM_READ(base_addr + KBD_FLASH_HEADER, &out->header, sizeof(out->header));
-
-  if (out->header.magic != KBD_CONFIG_MAGIC) return false;
-  if ((out->header.version >> 8) != (KBD_CONFIG_VERSION >> 8)) return false;
-
-  ReadConfigPayloadFromSlot(base_addr, &out->system, &out->keymap, &out->fnkey,
-                            &out->rgb);
-  if (CalcConfigCRC(&out->system, &out->keymap, &out->fnkey, &out->rgb) !=
-      out->header.crc32) {
-    return false;
-  }
   return true;
 }
 
@@ -726,7 +709,6 @@ int KBD_Config_Load(void) {
   bool found = false;
   kbd_config_slot_cache_t best = {0};
   kbd_config_slot_cache_t cur;
-  bool legacy_slot_loaded = false;
 
   for (uint8_t slot = 0; slot < KBD_CFG_SLOT_COUNT; slot++) {
     if (!TryLoadConfigSlot(slot, &cur)) continue;
@@ -738,30 +720,12 @@ int KBD_Config_Load(void) {
   }
 
   if (!found) {
-    /* 兼容旧布局：历史版本可能把完整配置写在 0x0C00~0x0FFF（现已改为 runtime 热数据区） */
-    if (TryLoadConfigAtAddr(KBD_RUNTIME_REGION_ADDR, 3, &best)) {
-      found = true;
-      legacy_slot_loaded = true;
-      LOG_W(TAG, "Loaded config from legacy slot3 (0x0C00), will migrate on save");
-    } else {
-      LOG_W(TAG, "No valid config slot found");
-      s_config_active_slot = KBD_CFG_INVALID_SLOT;
-      return -1;
-    }
+    LOG_W(TAG, "No valid config slot found");
+    s_config_active_slot = KBD_CFG_INVALID_SLOT;
+    return -1;
   }
 
   ApplyLoadedConfig(&best);
-
-  /* 迁移：旧配置可能无 indicator_brightness，若低于最低值则提升（不可完全关闭） */
-  if (s_rgb_config.indicator_brightness < KBD_INDICATOR_MIN_BRIGHTNESS) {
-    s_rgb_config.indicator_brightness = KBD_INDICATOR_MIN_BRIGHTNESS;
-  }
-
-  /* 迁移 v1.1 → v1.2: 初始化 HID 日志开关 */
-  if (s_config_header.version < 0x0102) {
-    s_system_config.log_enabled = KBD_LOG_DEFAULT_ENABLED;
-    LOG_I(TAG, "Migrated log config (v1.1->v1.2)");
-  }
 
 #if !KBD_USB_LOG_ENABLE
   s_system_config.log_enabled = 0;
@@ -769,14 +733,6 @@ int KBD_Config_Load(void) {
 
   /* 热数据（层号）独立覆盖，减少高频切层带来的整份配置写入 */
   ApplyRuntimeLayerIfValid();
-
-  /* 若从旧 slot3 加载，首次启动即迁移到新布局，避免后续 runtime 覆盖该区域后丢配置 */
-  if (legacy_slot_loaded) {
-    s_config_active_slot = KBD_CFG_INVALID_SLOT;
-    if (KBD_Config_Save() != 0) {
-      LOG_W(TAG, "Legacy config migration save failed");
-    }
-  }
 
   LOG_I(TAG, "Config loaded: slot=%d ver=0x%04X saves=%d", s_config_active_slot,
         s_config_header.version, s_config_header.save_count);

--- a/firmware/CH592F/usb/src/usb_device.c
+++ b/firmware/CH592F/usb/src/usb_device.c
@@ -8,6 +8,7 @@
 
 #include "usb_device.h"
 #include "debug.h"
+#include "kbd_mode.h"
 #include <string.h>
 
 #define TAG "USB"
@@ -21,7 +22,7 @@ uint8_t g_USB_SleepStatus = 0;
 uint8_t g_SetupReqCode = 0;
 uint16_t g_SetupReqLen = 0;
 const uint8_t *g_pDescriptor = NULL;
-static uint8_t g_SetupReqInterface = 0;  // 保存当前请求的接口号
+static uint8_t g_SetupReqInterface = 0; // 保存当前请求的接口号
 
 uint8_t g_IdleValue[4] = {0};
 uint8_t g_ProtocolValue[4] = {0};
@@ -346,10 +347,10 @@ void USB_Device_Deinit(void)
 {
     PFIC_DisableIRQ(USB_IRQn);
     R16_PIN_ANALOG_IE &= ~(RB_PIN_USB_IE | RB_PIN_USB_DP_PU); /* 移除 D+ 上拉与 USB 模拟使能 */
-    R8_UDEV_CTRL = 0;                                          /* 关闭 USB 端口 */
-    R8_USB_CTRL = 0;                                            /* 关闭 USB 模块 */
-    R8_USB_INT_EN = 0;                                          /* 清除中断使能 */
-    GPIOB_ModeCfg(GPIO_Pin_10 | GPIO_Pin_11, GPIO_ModeIN_PD);  /* USB D-/D+ 下拉，避免浮空干扰 */
+    R8_UDEV_CTRL = 0;                                         /* 关闭 USB 端口 */
+    R8_USB_CTRL = 0;                                          /* 关闭 USB 模块 */
+    R8_USB_INT_EN = 0;                                        /* 清除中断使能 */
+    GPIOB_ModeCfg(GPIO_Pin_10 | GPIO_Pin_11, GPIO_ModeIN_PD); /* USB D-/D+ 下拉，避免浮空干扰 */
     g_USB_DeviceState = USB_STATE_DETACHED;
 }
 
@@ -363,6 +364,11 @@ void USB_Device_TransferProcess(void)
 
     if (intflag & RB_UIF_TRANSFER)
     {
+        if (KBD_Mode_IsInSleep())
+        {
+            KBD_Mode_RequestWake();
+        }
+
         if ((R8_USB_INT_ST & MASK_UIS_TOKEN) != MASK_UIS_TOKEN)
         {
             switch (R8_USB_INT_ST & (MASK_UIS_TOKEN | MASK_UIS_ENDP))
@@ -445,6 +451,10 @@ void USB_Device_TransferProcess(void)
 
         if (R8_USB_INT_ST & RB_UIS_SETUP_ACT)
         {
+            if (KBD_Mode_IsInSleep())
+            {
+                KBD_Mode_RequestWake();
+            }
             USB_HandleSetupPacket();
             R8_USB_INT_FG = RB_UIF_TRANSFER;
         }
@@ -459,6 +469,10 @@ void USB_Device_TransferProcess(void)
         R8_UEP4_CTRL = UEP_R_RES_ACK | UEP_T_RES_NAK;
         R8_USB_INT_FG = RB_UIF_BUS_RST;
         g_USB_DeviceState = USB_STATE_DEFAULT;
+        if (KBD_Mode_IsInSleep())
+        {
+            KBD_Mode_RequestWake();
+        }
     }
     else if (intflag & RB_UIF_SUSPEND)
     {

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+  echo "[run] Do not run this script with sudo/root." >&2
+  echo "[run] It creates root-owned build artifacts and breaks later CMake builds." >&2
+  echo "[run] Use: ./run.sh" >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR"
 VENV_DIR="$PROJECT_ROOT/.venv"

--- a/tools/meowisp/crates/meowisp-core/src/isp.rs
+++ b/tools/meowisp/crates/meowisp-core/src/isp.rs
@@ -226,7 +226,7 @@ where
             progress(&label, stage_progress(done, total, 32, 78));
         })
         .map_err(|e| map_wchisp_error("flash/program", "刷写失败", e))?;
-    sleep(Duration::from_millis(500));
+    sleep(Duration::from_millis(1500));
     debug_line("flash: verify");
     let verify_label = byte_progress_label("校验固件", 0, data.len());
     progress(&verify_label, 80);

--- a/tools/meowisp/vendor-wchisp/src/flashing.rs
+++ b/tools/meowisp/vendor-wchisp/src/flashing.rs
@@ -403,8 +403,12 @@ impl<'a> Flashing<'a> {
         let padding = rand::random();
         let cmd = Command::verify(address, padding, xored.collect());
         let resp = self.transport.transfer(cmd)?;
-        anyhow::ensure!(resp.is_ok(), "verify response failed");
-        anyhow::ensure!(resp.payload()[0] == 0x00, "Verify failed, mismatch");
+        anyhow::ensure!(resp.is_ok(), "verify response failed at 0x{address:08x}");
+        anyhow::ensure!(
+            resp.payload()[0] == 0x00,
+            "Verify failed at 0x{address:08x}, mismatch status=0x{:02x}",
+            resp.payload()[0]
+        );
         Ok(())
     }
 

--- a/tools/scripts/common.py
+++ b/tools/scripts/common.py
@@ -222,9 +222,13 @@ def _candidate_wchisp_paths() -> list[Path]:
 
 def find_wchisp() -> Optional[Path]:
     binary = "wchisp.exe" if platform.system() == "Windows" else "wchisp"
+    meowisp_release = PROJECT_ROOT / "tools" / "meowisp" / "target" / "release" / binary
+    meowisp_debug = PROJECT_ROOT / "tools" / "meowisp" / "target" / "debug" / binary
     local = SCRIPT_DIR / binary
     candidates = _candidate_wchisp_paths()
     return resolve_tool_path(
         "wchisp", binary, env_name="WCHISP_PATH",
-        preferred_candidates=[local], candidates=candidates,
+        preferred_candidates=[meowisp_release, meowisp_debug, local],
+        preferred_before_cache=True,
+        candidates=candidates,
     )

--- a/tools/scripts/flash.py
+++ b/tools/scripts/flash.py
@@ -8,12 +8,74 @@ Supports: flash, verify, erase, reset, info, probe, eeprom, config
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 from common import colorize as _c, die, find_wchisp, info, ok, sep, warn
 from versioning import ch552_filename_for_keyboard, ch592_filename_for_keyboard
+
+
+KNOWN_BAD_CH59X_USER_CFG = "0x4FFF0FD5"
+
+
+def _run_capture(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(c) for c in cmd],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _extract_chip_name(output: str) -> str | None:
+    match = re.search(r"Chip:\s+([A-Za-z0-9]+)", output)
+    return match.group(1) if match else None
+
+
+def _extract_user_cfg(output: str) -> str | None:
+    match = re.search(r"USER_CFG:\s*(0x[0-9A-Fa-f]+)", output)
+    return match.group(1).upper() if match else None
+
+
+def _print_device_summary(output: str) -> None:
+    for line in output.splitlines():
+        if any(key in line for key in ("Chip:", "BTVER", "UID", "USER_CFG:")):
+            print(f"  {_c('2', line.strip())}")
+
+
+def _read_device_info(wchisp: Path, extra: list[str]) -> subprocess.CompletedProcess[str]:
+    return _run_capture([str(wchisp), "info"] + extra)
+
+
+def _repair_known_ch59x_verify_cfg(
+    wchisp: Path, extra: list[str], info_output: str
+) -> str:
+    chip_name = _extract_chip_name(info_output)
+    user_cfg = _extract_user_cfg(info_output)
+    if not chip_name or user_cfg != KNOWN_BAD_CH59X_USER_CFG:
+        return info_output
+    if not chip_name.startswith("CH59"):
+        return info_output
+
+    warn(
+        "Detected CH59x USER_CFG 0x4FFF0FD5, a known state that causes ISP verify to fail "
+        "after a successful write. Resetting config registers before flashing."
+    )
+    run([str(wchisp), "config", "reset"] + extra)
+
+    repaired = _read_device_info(wchisp, extra)
+    if repaired.returncode != 0:
+        die("Config reset succeeded, but the device could not be re-identified afterward.")
+
+    repaired_cfg = _extract_user_cfg(repaired.stdout)
+    if repaired_cfg == KNOWN_BAD_CH59X_USER_CFG:
+        die("Config reset did not clear the known-bad CH59x USER_CFG state.")
+
+    info("Config repair applied:")
+    _print_device_summary(repaired.stdout)
+    return repaired.stdout
 
 
 def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
@@ -27,23 +89,17 @@ def resolve_file(file_arg: str) -> Path:
     return path
 
 
-def check_device(wchisp: Path, extra: list[str]) -> None:
+def check_device(wchisp: Path, extra: list[str]) -> str:
     info("Checking for ISP device...")
-    result = subprocess.run(
-        [str(wchisp), "info"] + extra,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _read_device_info(wchisp, extra)
     if result.returncode != 0:
         die(
             "No WCH ISP device found.\n\n"
             f"  {_c('33', 'Hint: Hold BOOT button, then connect USB')}\n"
             f"        (or press RESET while holding BOOT)"
         )
-    for line in result.stdout.splitlines():
-        if any(key in line for key in ("Chip:", "BTVER", "UID")):
-            print(f"  {_c('2', line.strip())}")
+    _print_device_summary(result.stdout)
+    return result.stdout
 
 
 def confirm(prompt: str) -> None:
@@ -60,7 +116,8 @@ def confirm(prompt: str) -> None:
 def cmd_flash(args, wchisp: Path, extra: list[str]) -> None:
     file_path = resolve_file(args.file)
     sep()
-    check_device(wchisp, extra)
+    device_info = check_device(wchisp, extra)
+    _repair_known_ch59x_verify_cfg(wchisp, extra, device_info)
 
     flash_args: list[str] = []
     if args.skip_erase:
@@ -81,7 +138,12 @@ def cmd_flash(args, wchisp: Path, extra: list[str]) -> None:
 def cmd_verify(args, wchisp: Path, extra: list[str]) -> None:
     file_path = resolve_file(args.file)
     sep()
-    check_device(wchisp, extra)
+    device_info = check_device(wchisp, extra)
+    if _extract_chip_name(device_info or "") and _extract_user_cfg(device_info or "") == KNOWN_BAD_CH59X_USER_CFG:
+        warn(
+            "Detected CH59x USER_CFG 0x4FFF0FD5. This state is known to make ISP verify fail "
+            "even after a successful flash. Run flash once without --skip-verify to auto-repair it."
+        )
     sep()
     info(f"Verifying: {_c('1', file_path.name)}")
     run([str(wchisp), "verify"] + extra + [str(file_path)])

--- a/tools/scripts/targets/ch592/build.py
+++ b/tools/scripts/targets/ch592/build.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import os
 import platform
+import stat
 import re
 import shutil
 import subprocess
@@ -227,6 +228,40 @@ def user_facing_artifact_paths(build_dir: Path, keyboard: str) -> dict[str, Path
     }
 
 
+def _directory_is_writable(path: Path) -> bool:
+    if not path.exists():
+        probe = path.parent
+        while not probe.exists() and probe != probe.parent:
+            probe = probe.parent
+        return probe.exists() and os.access(probe, os.W_OK)
+    mode = path.stat().st_mode
+    return path.is_dir() and bool(mode & stat.S_IWUSR) and os.access(path, os.W_OK)
+
+
+def _ensure_writable_build_dir(build_dir: Path, action: str) -> None:
+    if _directory_is_writable(build_dir):
+        return
+
+    owner_uid = build_dir.stat().st_uid if build_dir.exists() else None
+    owner_text = f"uid {owner_uid}" if owner_uid is not None else "unknown owner"
+    try:
+        import pwd
+
+        if owner_uid is not None:
+            owner_text = pwd.getpwuid(owner_uid).pw_name
+    except Exception:
+        pass
+
+    build_root = FIRMWARE_DIR / "build"
+    die(
+        f"Cannot {action}: build directory is not writable: {build_dir}\n"
+        f"Owner: {owner_text}\n"
+        "This usually happens after running ./run.sh with sudo and leaving root-owned CH592F build artifacts behind.\n"
+        f"Fix it with:\n  sudo chown -R $USER '{build_root}'\n"
+        f"Or remove '{build_root}' and rebuild without sudo."
+    )
+
+
 def export_named_artifacts(build_dir: Path, keyboard: str) -> dict[str, Path]:
     raw = raw_artifact_paths(build_dir)
     exported = artifact_paths(build_dir, keyboard)
@@ -234,7 +269,11 @@ def export_named_artifacts(build_dir: Path, keyboard: str) -> dict[str, Path]:
         src = raw[name]
         dst = exported[name]
         if src.is_file() and src != dst:
-            shutil.copy2(src, dst)
+            try:
+                shutil.copy2(src, dst)
+            except PermissionError:
+                _ensure_writable_build_dir(build_dir, f"export {dst.name}")
+                raise
     return exported
 
 
@@ -360,6 +399,7 @@ def configure(keyboard: str, profile: str) -> Path:
     profile = _normalize_profile(profile)
     build_dir = build_dir_for(keyboard, profile)
     build_dir.mkdir(parents=True, exist_ok=True)
+    _ensure_writable_build_dir(build_dir, "configure CH592F build outputs")
     sep()
     info(f"Configuring CH592F ({keyboard}, {profile})")
     run(
@@ -378,6 +418,7 @@ def build(keyboard: str, profile: str) -> Path:
     keyboard = _normalize_keyboard(keyboard)
     profile = _normalize_profile(profile)
     build_dir = build_dir_for(keyboard, profile)
+    _ensure_writable_build_dir(build_dir, "build CH592F artifacts")
     cache_file = build_dir / "CMakeCache.txt"
     cached_keyboard = _parse_cmake_cache_var(cache_file, "KEYBOARD")
     cached_model = _parse_cmake_cache_var(cache_file, "KBD_MODEL")

--- a/tools/scripts/tool_cache.py
+++ b/tools/scripts/tool_cache.py
@@ -85,6 +85,7 @@ def resolve_tool_path(
     *,
     env_name: str | None = None,
     preferred_candidates: Iterable[Path] = (),
+    preferred_before_cache: bool = False,
     candidates: Iterable[Path] = (),
 ) -> Optional[Path]:
     env_path = os.environ.get(env_name, "") if env_name else ""
@@ -93,6 +94,13 @@ def resolve_tool_path(
         if resolved:
             _update_cached_tool(cache_key, resolved)
             return resolved
+
+    if preferred_before_cache:
+        for candidate in preferred_candidates:
+            resolved = _normalize_path(candidate, binary_name)
+            if resolved:
+                _update_cached_tool(cache_key, resolved)
+                return resolved
 
     cached = _read_tool_cache().get(cache_key, "")
     if cached:

--- a/tools/studio/src/components/RgbPanel.vue
+++ b/tools/studio/src/components/RgbPanel.vue
@@ -65,6 +65,28 @@
         </select>
       </div>
 
+      <div v-if="showSleepConfig" class="rgb-item">
+        <span class="rgb-label">LIGHT 休眠（分钟，0=禁用）</span>
+        <input
+          v-model.number="deviceStore.rgbConfig.lightSleepMin"
+          type="number"
+          min="0"
+          max="255"
+          class="rgb-number-input"
+        />
+      </div>
+
+      <div v-if="showSleepConfig" class="rgb-item">
+        <span class="rgb-label">DEEP 延时（在 LIGHT 后，分钟，0=禁用）</span>
+        <input
+          v-model.number="deviceStore.rgbConfig.deepSleepMin"
+          type="number"
+          min="0"
+          max="255"
+          class="rgb-number-input"
+        />
+      </div>
+
       <div v-if="deviceStore.deviceInfo?.protocol === DeviceProtocol.CH552" class="rgb-item">
         <span class="rgb-label">USB 轮询率</span>
         <select v-model.number="pollRateModel" class="rgb-select">
@@ -129,6 +151,10 @@ const showColorPicker = computed(
 );
 
 const showIndicatorBrightness = computed(
+  () => deviceStore.deviceInfo?.protocol === DeviceProtocol.CH592,
+);
+
+const showSleepConfig = computed(
   () => deviceStore.deviceInfo?.protocol === DeviceProtocol.CH592,
 );
 
@@ -214,6 +240,15 @@ async function saveRgb() {
 }
 
 .rgb-select {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--c-border);
+  background: var(--c-bg-tertiary);
+  color: var(--c-text-primary);
+  font-size: 0.85rem;
+}
+
+.rgb-number-input {
   padding: 6px 8px;
   border-radius: 6px;
   border: 1px solid var(--c-border);

--- a/tools/studio/src/services/hid/devices/ch592/codec.ts
+++ b/tools/studio/src/services/hid/devices/ch592/codec.ts
@@ -235,13 +235,15 @@ export class Ch592Codec implements DeviceCodec<DataView> {
       colorG: resp.getUint8(d + 6),
       colorB: resp.getUint8(d + 7),
       indicatorEnabled: resp.getUint8(d + 8) !== 0,
-      indicatorBrightness: resp.byteLength >= d + 10 ? resp.getUint8(d + 9) : resp.getUint8(d + 3),
-      pressEffect: resp.byteLength >= d + 11 ? resp.getUint8(d + 10) : PressEffect.NONE,
+      indicatorBrightness: resp.getUint8(d + 9),
+      pressEffect: resp.getUint8(d + 10),
+      lightSleepMin: resp.getUint8(d + 11),
+      deepSleepMin: resp.getUint8(d + 12),
     };
   }
 
   buildSetRgbPayload(config: RgbConfig): Uint8Array {
-    const data = new Uint8Array(10);
+    const data = new Uint8Array(12);
     data[0] = config.enabled ? 1 : 0;
     data[1] = config.mode;
     data[2] = config.brightness;
@@ -250,8 +252,10 @@ export class Ch592Codec implements DeviceCodec<DataView> {
     data[5] = config.colorG;
     data[6] = config.colorB;
     data[7] = config.indicatorEnabled ? 1 : 0;
-    data[8] = config.indicatorBrightness ?? config.brightness;
-    data[9] = config.pressEffect ?? PressEffect.NONE;
+    data[8] = config.indicatorBrightness;
+    data[9] = config.pressEffect;
+    data[10] = config.lightSleepMin!;
+    data[11] = config.deepSleepMin!;
     return data;
   }
 

--- a/tools/studio/src/types/protocol.ts
+++ b/tools/studio/src/types/protocol.ts
@@ -406,6 +406,8 @@ export interface RgbConfig {
   indicatorEnabled: boolean;
   indicatorBrightness: number; /**< 指示灯亮度 (0-255) */
   pressEffect: PressEffect;
+  lightSleepMin?: number; /**< LIGHT 休眠时间（分钟，0=禁用） */
+  deepSleepMin?: number; /**< DEEP 延时（在 LIGHT 后，分钟，0=禁用） */
   pollRate?: number; /**< USB HID 轮询率 bInterval (1=1000Hz, 2=500Hz, 5=200Hz, 10=100Hz) */
 }
 
@@ -621,6 +623,8 @@ export function createDefaultRgbConfig(): RgbConfig {
     indicatorEnabled: true,
     indicatorBrightness: RGB_DEFAULT_BRIGHTNESS,
     pressEffect: PressEffect.NONE,
+    lightSleepMin: 1,
+    deepSleepMin: 1,
     pollRate: 10,
   };
 }


### PR DESCRIPTION
Fixes #13

This PR completes the wireless keyboard low-power and battery-related work by:

- switching CH592 sleep behavior to configurable LIGHT/DEEP timeouts
- preventing BLE auto-advertising resume before deep sleep shutdown
- preserving JumpIAP vector/reset layout for reliable handoff
- tightening config version migration and layer-to-key LED mapping
- improving CH59x flashing/tool selection, verify diagnostics, and root-owned build-dir handling
- exposing the new sleep settings in Studio and syncing component versions