### PR TITLE
fix(ci): 修复 Pages 构建与固件同步

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,7 +9,7 @@ on:
       - ".github/scripts/**"
       - ".github/workflows/deploy-docs.yml"
   workflow_run:
-    workflows: ["Release Firmware and MeowISP"]
+    workflows: ["Release Firmware and BinaryKeyboard ISP"]
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -754,9 +754,9 @@ jobs:
       - name: Organize firmware for Pages
         run: |
           mkdir -p dist/firmware/ch592f dist/firmware/ch552g
-          cp dist/CH592F-*-app.bin dist/firmware/ch592f/ 2>/dev/null || true
-          cp dist/CH592F-*-full.bin dist/firmware/ch592f/ 2>/dev/null || true
-          cp dist/CH552G-*.hex dist/firmware/ch552g/ 2>/dev/null || true
+          cp dist/CH592F-*-app.bin dist/firmware/ch592f/
+          cp dist/CH592F-*-full.bin dist/firmware/ch592f/
+          cp dist/CH552G-*.bin dist/firmware/ch552g/
 
       - name: Upload pages-firmware artifact
         uses: actions/upload-artifact@v4

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -61,8 +61,8 @@ https://meowkj.github.io/BinaryKeyboard/
 ```bash
 # Firmware + manifest are now provided via the pages-firmware workflow artifact
 # from the latest successful Release Firmware run. Place them manually:
-#   docs/public/firmware/ch592f/  — full.hex + app.bin
-#   docs/public/firmware/ch552g/  — hex
+#   docs/public/firmware/ch592f/  — full.bin + app.bin
+#   docs/public/firmware/ch552g/  — bin
 #   docs/public/api/release-manifest.json
 
 cd docs

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - .
 
+allowBuilds:
+  esbuild: true
+
 overrides:
   esbuild: 0.27.1
   postcss: 8.5.15

--- a/tools/meowisp/crates/meowisp-core/src/online.rs
+++ b/tools/meowisp/crates/meowisp-core/src/online.rs
@@ -78,6 +78,8 @@ struct ManifestCh592Artifact {
 #[derive(Debug, Deserialize)]
 struct ManifestCh552Artifact {
     version: String,
+    #[serde(rename = "binUrl")]
+    bin_url: Option<String>,
     #[serde(rename = "hexUrl")]
     hex_url: Option<String>,
 }
@@ -321,10 +323,15 @@ fn fetch_manifest_assets() -> Result<Vec<ReleaseAsset>, String> {
     }
 
     for (keyboard, artifact) in &manifest.artifacts.ch552 {
-        let Some(url) = artifact.hex_url.as_ref() else {
+        let Some(url) = artifact.bin_url.as_ref().or(artifact.hex_url.as_ref()) else {
             continue;
         };
         let name = filename_from_url(url);
+        let flavor = if name.to_ascii_lowercase().ends_with(".hex") {
+            "hex"
+        } else {
+            "bin"
+        };
         let (category, family) = categorize("CH552G");
         assets.push(manifest_asset(
             name,
@@ -335,7 +342,7 @@ fn fetch_manifest_assets() -> Result<Vec<ReleaseAsset>, String> {
                 chip: "CH552G".into(),
                 keyboard: keyboard.to_ascii_uppercase(),
                 version: artifact.version.clone(),
-                flavor: "hex".into(),
+                flavor: flavor.into(),
                 category,
                 family,
             },

--- a/tools/scripts/versioning.py
+++ b/tools/scripts/versioning.py
@@ -372,7 +372,7 @@ def release_artifact_manifest(build_number: int | None = None) -> tuple[dict[str
         return {
             "channel": "release",
             "version": version,
-            "hexUrl": f"{base_url}/firmware/ch552g/CH552G-{model}-{version}.hex",
+            "binUrl": f"{base_url}/firmware/ch552g/CH552G-{model}-{version}.bin",
         }
 
     return ({


### PR DESCRIPTION
## 变更
- 允许文档工作区执行 esbuild 安装脚本，修复 pnpm 11 自动构建失败
- 修正 Pages 对已改名 Release workflow 的监听
- 统一 CH552 Pages 固件与发布清单为实际发布的 BIN 格式
- BinaryKeyboard ISP 支持 binUrl，并兼容旧版 hexUrl 清单
- 固件归档缺失时立即失败，避免发布不完整 artifact

## 验证
- pnpm install --frozen-lockfile（docs）
- pnpm run build（docs）
- pnpm run type-check（Studio）
- pnpm run build-only（Studio）
- cargo test --manifest-path tools/meowisp/Cargo.toml -p meowisp-core
- python -m compileall -q tools/scripts
- Release 清单 URL 与 workflow 名称一致性检查
- git diff --check