### PR TITLE
fix(studio): 修复欢迎页布局与图标

### DIFF
--- a/tools/studio/src/composables/useConnection.ts
+++ b/tools/studio/src/composables/useConnection.ts
@@ -100,11 +100,14 @@ export function useConnection() {
 
   async function connectAuthorizedDevice(
     successTitle: string,
+    notifyMissingDevice = true,
   ): Promise<boolean> {
     const device = await hidService.getAuthorizedDevice();
     if (!device) {
-      showToast("error", "连接失败", "未找到已授权设备");
-      onConnectionResult(false);
+      if (notifyMissingDevice) {
+        showToast("error", "连接失败", "未找到已授权设备");
+        onConnectionResult(false);
+      }
       return false;
     }
     return connectAndInitialize(device, successTitle);
@@ -130,7 +133,8 @@ export function useConnection() {
   }
 
   async function autoConnect() {
-    await connectAuthorizedDevice("自动连接");
+    // 首次打开 Studio 时没有授权过设备是正常状态，不应以错误提示遮挡欢迎页。
+    await connectAuthorizedDevice("自动连接", false);
   }
 
   async function disconnect() {

--- a/tools/studio/src/views/WelcomeView.vue
+++ b/tools/studio/src/views/WelcomeView.vue
@@ -102,7 +102,7 @@ const linkButtons = [
         </div>
         <div class="version-badges">
           <div class="version-badge studio-badge">
-            <div class="badge-icon"><CatEmoji /></div>
+            <div class="badge-icon"><CatEmoji type="desktop-computer-3d" /></div>
             <div class="badge-info">
               <span class="badge-label">Studio 最新</span>
               <span class="badge-version">v{{ releaseStore.latestStudioVersion }}</span>
@@ -264,8 +264,9 @@ const linkButtons = [
 }
 
 .connect-button {
-  width: calc(100% - 2rem);
-  margin-inline: 1rem;
+  width: 11rem;
+  max-width: 100%;
+  margin-inline: 0;
   font-size: 1.1rem !important;
   font-weight: 700 !important;
   padding: 0.875rem 1.5rem !important;


### PR DESCRIPTION
## 变更
- 首次打开 Studio 且没有已授权设备时静默停留欢迎页，避免错误 Toast 遮住顶部猫
- 收窄连接按钮，恢复与卡片内容的视觉层级
- 将 Studio 版本徽章左侧图片改为桌面电脑图标

## 验证
- pnpm run type-check
- pnpm run build-only
- 1280×720 桌面端浏览器渲染检查
- 390×844 移动端浏览器渲染检查
- 首屏无 Toast、猫完整显示、连接按钮为 176px
- Studio 版本徽章图标资源检查
- git diff --check