### PR TITLE
fix(studio): 清理遗留 PWA 缓存

### DIFF
--- a/tools/studio/public/sw.js
+++ b/tools/studio/public/sw.js
@@ -1,0 +1,25 @@
+/*
+ * Retire service workers left behind by older Studio PWA deployments.
+ *
+ * The current web build does not register a service worker, but browsers that
+ * visited a historical PWA build can otherwise keep serving its precache
+ * indefinitely. Publishing this file at the original /sw.js URL lets those
+ * registrations update once, clear their caches, and unregister themselves.
+ */
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+    await self.registration.unregister();
+
+    const windows = await self.clients.matchAll({
+      type: "window",
+      includeUncontrolled: true,
+    });
+    await Promise.all(windows.map((client) => client.navigate(client.url)));
+  })());
+});

--- a/tools/studio/src/App.vue
+++ b/tools/studio/src/App.vue
@@ -91,6 +91,19 @@ const {
 // 主题系统
 const { themeId, themeMode, toggleMode, init: initTheme } = useTheme();
 
+async function cleanupLegacyPwa() {
+  if (!("serviceWorker" in navigator)) return;
+
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  if (registrations.length === 0) return;
+
+  await Promise.all(registrations.map((registration) => registration.unregister()));
+  if ("caches" in window) {
+    const cacheNames = await caches.keys();
+    await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
+  }
+}
+
 // PWA
 const { needRefresh: pwaNeedRefresh, updateServiceWorker } = useRegisterSW({
   onRegistered(r: ServiceWorkerRegistration | undefined) {
@@ -108,6 +121,9 @@ async function onPwaUpdate() {
 
 // 生命周期
 onMounted(async () => {
+  await cleanupLegacyPwa().catch((error) => {
+    console.warn("[PWA] 清理历史 Service Worker 失败", error);
+  });
   initTheme();
   void releaseStore.loadLatestVersions();
   if (HidService.isSupported()) {


### PR DESCRIPTION
## 根因
- 当前 Vercel 构建已不再发布 PWA，但历史版本安装过的 Service Worker 仍会持续返回旧首页缓存
- 新部署没有 /sw.js，旧 Worker 无法更新或自我注销，导致部分老用户看不到 UI 变化

## 修复
- 在原 /sw.js 路径发布一次性退役 Worker，清除旧缓存、注销注册并重新导航
- Studio 启动时主动注销同源遗留 Worker 并清理 Cache Storage
- 清理失败时仅记录警告，不影响应用启动

## 验证
- pnpm run type-check
- 普通生产构建通过
- 确认 dist/sw.js 为退役 Worker
- node --check public/sw.js
- git diff --check