### PR TITLE
fix(studio): 移除欢迎页连接提示

### DIFF
--- a/tools/studio/src/views/WelcomeView.vue
+++ b/tools/studio/src/views/WelcomeView.vue
@@ -66,13 +66,7 @@ const linkButtons = [
             <CatEmoji type="hourglass-not-done-animated" class="connecting-hourglass" />
             <span class="connecting-text">正在连接...</span>
           </div>
-          <template v-else>
-            <Button label="连接键盘" icon="pi pi-usb" size="large" @click="emit('connect')" class="connect-button" />
-            <p class="connect-hint">
-              <i class="pi pi-info-circle"></i>
-              无线款可保持蓝牙模式，插入 USB 后直接配置
-            </p>
-          </template>
+          <Button v-else label="连接键盘" icon="pi pi-usb" size="large" @click="emit('connect')" class="connect-button" />
         </div>
       </div>
 
@@ -271,16 +265,6 @@ const linkButtons = [
   font-weight: 700 !important;
   padding: 0.875rem 1.5rem !important;
   justify-content: center;
-}
-
-.connect-hint {
-  margin: 1rem 0 0;
-  font-size: 0.85rem;
-  color: var(--c-text-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
 }
 
 /* 连接中覆盖层 */


### PR DESCRIPTION
## 变更
- 移除欢迎页连接卡片中的无线模式说明
- 删除对应提示样式，不保留占位
- 连接卡片仅展示键盘预览和连接按钮

## 验证
- pnpm run type-check
- pnpm run build-only
- 1280×720 浏览器渲染检查
- 提示文本不存在、connect-hint 节点数量为 0
- git diff --check